### PR TITLE
Grafana project

### DIFF
--- a/terraform/grafana/certificates.tf
+++ b/terraform/grafana/certificates.tf
@@ -1,0 +1,21 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "grafana.relops.mozops.net"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+}

--- a/terraform/grafana/datasources.tf
+++ b/terraform/grafana/datasources.tf
@@ -1,0 +1,21 @@
+# Look up usw2 vpc
+data "aws_vpcs" "moz_internal_us_west_2" {
+  provider = "aws.us-west-2"
+
+  tags = {
+    Name = "moz-internal-us-west-2"
+  }
+}
+
+# Lookup public subnets of usw2 vpc
+data "aws_subnet_ids" "public_subnets" {
+  vpc_id = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  tags = {
+    Subnet_type = "public"
+  }
+}
+
+data "aws_route53_zone" "relops_mozops_net" {
+  name = "relops.mozops.net."
+}

--- a/terraform/grafana/ecs-cluster.tf
+++ b/terraform/grafana/ecs-cluster.tf
@@ -1,0 +1,108 @@
+resource "aws_ecs_cluster" "main" {
+  name = "grafana"
+
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "grafana"
+    )
+  )}"
+}
+
+resource "aws_security_group" "ecs_public_sg" {
+  name        = "ecs_grafana"
+  description = "Allow grafana ecs inbound traffic"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port       = "${var.app_port}"
+    to_port         = "${var.app_port}"
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.lb_sg.id}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "grafana"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = "${aws_iam_role.ecs-task-exec-role.arn}"
+  cpu                      = "${var.fargate_cpu}"
+  memory                   = "${var.fargate_memory}"
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": ${var.fargate_cpu},
+    "image": "${var.app_image}",
+    "memory": ${var.fargate_memory},
+    "name": "grafana",
+    "environment" : [
+      { "name" : "GF_DATABASE_TYPE", "value" : "mysql" },
+      { "name" : "GF_DATABASE_HOST", "value" : "${aws_db_instance.mysql.endpoint}" },
+      { "name" : "GF_DATABASE_USER", "value" : "${var.db_username}" }
+    ],
+    "secrets": [
+        {
+            "name" : "GF_SECURITY_ADMIN_PASSWORD",
+            "valueFrom" : "arn:aws:ssm:us-west-2:961225894672:parameter/grafana_admin_password"
+        },
+        {
+            "name": "GF_DATABASE_PASSWORD",
+            "valueFrom": "arn:aws:ssm:us-west-2:961225894672:parameter/grafana_db_password"
+        }
+    ],
+    "networkMode": "awsvpc",
+    "portMappings": [
+      {
+        "containerPort": ${var.app_port},
+        "hostPort": ${var.app_port}
+      }
+    ]
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "grafana"
+  cluster         = "${aws_ecs_cluster.main.id}"
+  task_definition = "${aws_ecs_task_definition.app.arn}"
+  desired_count   = "${var.app_count}"
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = ["${data.aws_subnet_ids.public_subnets.ids}"]
+    security_groups  = ["${aws_security_group.ecs_public_sg.id}"]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+    container_name   = "grafana"
+    container_port   = 3000
+  }
+
+  depends_on = ["aws_lb_listener.front_end", "aws_ecs_task_definition.app"]
+}

--- a/terraform/grafana/ecs-task-exec-role.tf
+++ b/terraform/grafana/ecs-task-exec-role.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs-task-exec-role" {
+  name               = "grafana-ecs-task-exec-role"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-assume-role-policy.json}"
+}
+
+resource "aws_iam_policy" "secrets_read_policy" {
+  name        = "grafana-SSMAllow"
+  description = "Allow grafana to read from ssm"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Resource": [
+        "arn:aws:ssm:us-west-2:961225894672:parameter/grafana_*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
+  role       = "${aws_iam_role.ecs-task-exec-role.name}"
+  policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
+}

--- a/terraform/grafana/lb.tf
+++ b/terraform/grafana/lb.tf
@@ -1,0 +1,85 @@
+resource "aws_lb" "lb" {
+  name               = "grafana-load-balancer"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.lb_sg.id}"]
+  subnets            = ["${data.aws_subnet_ids.public_subnets.ids}"]
+
+  enable_deletion_protection = false
+}
+
+resource "aws_security_group" "lb_sg" {
+  name        = "grafana-lb-sg"
+  description = "Allow grafana traffic into load balancer"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_lb_target_group" "lb_target_group" {
+  name        = "grafana-lb-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  health_check {
+    path                = "/api/health"
+    port                = 3000
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.lb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+  }
+}
+
+resource "aws_route53_record" "grafana" {
+  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  name    = "grafana.relops.mozops.net"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.lb.dns_name}"
+    zone_id                = "${aws_lb.lb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/terraform/grafana/mysql.tf
+++ b/terraform/grafana/mysql.tf
@@ -1,0 +1,67 @@
+resource "aws_security_group" "mysql_sg" {
+  name        = "grafana-mysql-sg"
+  description = "Allow inbound traffic into grafana mysql"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.ecs_public_sg.id}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_db_subnet_group" "mysql" {
+  name       = "grafana"
+  subnet_ids = ["${data.aws_subnet_ids.public_subnets.ids}"]
+
+  tags = {
+    Name        = "grafana rds subnet group"
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_db_instance" "mysql" {
+  identifier_prefix           = "grafana"
+  allocated_storage           = 30
+  allow_major_version_upgrade = "true"
+  auto_minor_version_upgrade  = "true"
+  apply_immediately           = "true"
+  storage_type                = "gp2"
+  engine                      = "mysql"
+  engine_version              = "5.7.23"
+  instance_class              = "db.t2.micro"
+  skip_final_snapshot         = "true"
+  name                        = "grafana"
+  username                    = "${var.db_username}"
+
+  # Password must be changed after provision
+  password               = "XXXXXXXXXXXX"
+  multi_az               = "true"
+  db_subnet_group_name   = "${aws_db_subnet_group.mysql.id}"
+  vpc_security_group_ids = ["${aws_security_group.mysql_sg.id}"]
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}

--- a/terraform/grafana/terraform.tfvars
+++ b/terraform/grafana/terraform.tfvars
@@ -1,1 +1,13 @@
 tag_project_name = "grafana"
+
+app_count = 1
+
+app_image = "grafana/grafana:6.0.0"
+
+fargate_cpu = 512
+
+fargate_memory = 1024
+
+app_port = 3000
+
+db_username = "grafana"

--- a/terraform/grafana/vars.tf
+++ b/terraform/grafana/vars.tf
@@ -1,0 +1,23 @@
+variable "app_count" {
+  description = "Number of application instances"
+}
+
+variable "app_image" {
+  description = "Docker Hub slug"
+}
+
+variable "fargate_cpu" {
+  description = "Maximum number of instances in the cluster"
+}
+
+variable "fargate_memory" {
+  description = "Minimum number of instances in the cluster"
+}
+
+variable "app_port" {
+  description = "Port number of application"
+}
+
+variable "db_username" {
+  description = "Database username"
+}


### PR DESCRIPTION
        These terraform configs set up a simple public grafana service.
        It consists of a dedicated ecs cluster w/single fargate task, a
        load balanace with an attached dns mozops.net record and
        corresponding ssl cert.  It also sets up a multi-az mysql rds
        instance for the application backend.  Container secrets are
        store and curated by hand in ssm parameter store.