### PR TITLE
Grafana update

### DIFF
--- a/terraform/grafana/ecs-task-exec-role.tf
+++ b/terraform/grafana/ecs-task-exec-role.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }

--- a/terraform/grafana/terraform.tfvars
+++ b/terraform/grafana/terraform.tfvars
@@ -2,7 +2,7 @@ tag_project_name = "grafana"
 
 app_count = 1
 
-app_image = "grafana/grafana:6.0.0"
+app_image = "grafana/grafana:6.0.2"
 
 fargate_cpu = 512
 


### PR DESCRIPTION
Switch task exec role to trust ecs-task and not ec2. The current deploy is runing with this applied.