### PR TITLE
Telegraf service

### DIFF
--- a/terraform/base/tf_state_lock_telegraf.tf
+++ b/terraform/base/tf_state_lock_telegraf.tf
@@ -1,0 +1,19 @@
+resource "aws_dynamodb_table" "tf_state_lock_telegraf" {
+  name           = "tf_state_lock_telegraf"
+  hash_key       = "LockID"
+  read_capacity  = 20
+  write_capacity = 20
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags {
+    Name        = "telegraf Terraform State Lock Table"
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "prod"
+    Owner       = "relops@mozilla.com"
+  }
+}

--- a/terraform/telegraf/backend.tf
+++ b/terraform/telegraf/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "relops-tf-states"
+    key            = "telegraf.tfstate"
+    dynamodb_table = "tf_state_lock_telegraf"
+    region         = "us-west-2"
+  }
+}

--- a/terraform/telegraf/certificates.tf
+++ b/terraform/telegraf/certificates.tf
@@ -1,0 +1,21 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "telegraf.relops.mozops.net"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+}

--- a/terraform/telegraf/cloudwatch-log-group.tf
+++ b/terraform/telegraf/cloudwatch-log-group.tf
@@ -1,0 +1,12 @@
+resource "aws_cloudwatch_log_group" "telegraf" {
+  name = "telegraf"
+
+  retention_in_days = 14
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}

--- a/terraform/telegraf/datasources.tf
+++ b/terraform/telegraf/datasources.tf
@@ -1,0 +1,21 @@
+# Look up usw2 vpc
+data "aws_vpcs" "moz_internal_us_west_2" {
+  provider = "aws.us-west-2"
+
+  tags = {
+    Name = "moz-internal-us-west-2"
+  }
+}
+
+# Lookup public subnets of usw2 vpc
+data "aws_subnet_ids" "public_subnets" {
+  vpc_id = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  tags = {
+    Subnet_type = "public"
+  }
+}
+
+data "aws_route53_zone" "relops_mozops_net" {
+  name = "relops.mozops.net."
+}

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -50,6 +50,7 @@ resource "aws_ecs_task_definition" "app" {
   execution_role_arn       = "${aws_iam_role.ecs-task-exec-role.arn}"
   cpu                      = "${var.fargate_cpu}"
   memory                   = "${var.fargate_memory}"
+  depends_on               = ["aws_iam_role.ecs-task-exec-role"]      # force recreate on change sha in definition
 
   container_definitions = <<DEFINITION
 [
@@ -59,6 +60,7 @@ resource "aws_ecs_task_definition" "app" {
     "memory": ${var.fargate_memory},
     "name": "telegraf",
     "environment" : [
+      { "name" : "policy_sha1", "value" : "${sha1(file("ecs-task-exec-role.tf"))}" },
       { "name" : "INFLUXDB_URL", "value" : "${var.influxdb_url}" },
       { "name" : "INFLUXDB_USER", "value" : "${var.influxdb_user}" },
       { "name" : "INFLUXDB_DB", "value" : "${var.influxdb_db}" },

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -1,0 +1,103 @@
+resource "aws_ecs_cluster" "main" {
+  name = "telegraf"
+
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "telegraf"
+    )
+  )}"
+}
+
+resource "aws_security_group" "ecs_public_sg" {
+  name        = "ecs_telegraf"
+  description = "Allow telegraf ecs inbound traffic"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port       = "${var.app_port}"
+    to_port         = "${var.app_port}"
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.lb_sg.id}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "telegraf"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = "${aws_iam_role.ecs-task-exec-role.arn}"
+  cpu                      = "${var.fargate_cpu}"
+  memory                   = "${var.fargate_memory}"
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": ${var.fargate_cpu},
+    "image": "${var.app_image}",
+    "memory": ${var.fargate_memory},
+    "name": "telegraf",
+    "environment" : [
+      { "name" : "INFLUXDB_HOST", "value" : "host" },
+      { "name" : "INFLUXDB_USER", "value" : "relops" }
+    ],
+    "secrets": [
+        {
+            "name": "INFLUXDB_PASSWORD",
+            "valueFrom": "arn:aws:ssm:us-west-2:961225894672:parameter/influxdb_wo_password"
+        }
+    ],
+    "networkMode": "awsvpc",
+    "portMappings": [
+      {
+        "containerPort": ${var.app_port},
+        "hostPort": ${var.app_port}
+      }
+    ]
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "telegraf"
+  cluster         = "${aws_ecs_cluster.main.id}"
+  task_definition = "${aws_ecs_task_definition.app.arn}"
+  desired_count   = "${var.app_count}"
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = ["${data.aws_subnet_ids.public_subnets.ids}"]
+    security_groups  = ["${aws_security_group.ecs_public_sg.id}"]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+    container_name   = "telegraf"
+    container_port   = 8086
+  }
+
+  depends_on = ["aws_lb_listener.front_end", "aws_ecs_task_definition.app"]
+}

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -59,8 +59,12 @@ resource "aws_ecs_task_definition" "app" {
     "memory": ${var.fargate_memory},
     "name": "telegraf",
     "environment" : [
-      { "name" : "INFLUXDB_HOST", "value" : "host" },
-      { "name" : "INFLUXDB_USER", "value" : "relops" }
+      { "name" : "INFLUXDB_URL", "value" : "${var.influxdb_url}" },
+      { "name" : "INFLUXDB_USER", "value" : "${var.influxdb_user}" },
+      { "name" : "INFLUXDB_DB", "value" : "${var.influxdb_db}" },
+      { "name" : "INTERVAL", "value" : "${var.interval}" },
+      { "name" : "MEDIUM_INTERVAL", "value" : "${var.medium_interval}" },
+      { "name" : "LONG_INTERVAL", "value" : "${var.long_interval}" }
     ],
     "secrets": [
         {
@@ -74,7 +78,15 @@ resource "aws_ecs_task_definition" "app" {
         "containerPort": ${var.app_port},
         "hostPort": ${var.app_port}
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.telegraf.name}",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "telegraf"
+      }
+    }
   }
 ]
 DEFINITION

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -57,8 +57,9 @@ resource "aws_iam_policy" "ecr_policy" {
         "logs:*"
       ],
       "Resource": [
-        "arn:aws:ecr:us-west-2:961225894672:repository/*",
-        "arn:aws:logs:::*"
+        "arn:aws:ecr:us-west-2:961225894672:*",
+        "*",
+        "arn:aws:logs:us-west-2::*"
       ]
     }
   ]

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -41,3 +41,32 @@ resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
   role       = "${aws_iam_role.ecs-task-exec-role.name}"
   policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
 }
+
+resource "aws_iam_policy" "ecr_policy" {
+  name        = "telegraf-ECRAllow"
+  description = "Allow telegraf to read from ecr"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:*",
+        "logs:*"
+      ],
+      "Resource": [
+        "arn:aws:ecr:us-west-2:961225894672:repository/*",
+        "arn:aws:logs:::*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ecr_policy" {
+  role       = "${aws_iam_role.ecs-task-exec-role.name}"
+  policy_arn = "${aws_iam_policy.ecr_policy.arn}"
+}

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs-task-exec-role" {
+  name               = "telegraf-ecs-task-exec-role"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-assume-role-policy.json}"
+}
+
+resource "aws_iam_policy" "secrets_read_policy" {
+  name        = "telegraf-SSMAllow"
+  description = "Allow telegraf to read from ssm"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Resource": [
+        "arn:aws:ssm:us-west-2:961225894672:parameter/influx*",
+        "arn:aws:ssm:us-west-2:961225894672:parameter/telegraf*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
+  role       = "${aws_iam_role.ecs-task-exec-role.name}"
+  policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
+}

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }

--- a/terraform/telegraf/lb.tf
+++ b/terraform/telegraf/lb.tf
@@ -44,18 +44,18 @@ resource "aws_security_group" "lb_sg" {
 
 resource "aws_lb_target_group" "lb_target_group" {
   name        = "telegraf-lb-tg"
-  port        = 8086
+  port        = "${var.app_port}"
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
 
   health_check {
-    path                = "/api/health"
-    port                = 8086
+    path                = "/ping"
+    port                = "${var.app_port}"
     healthy_threshold   = 3
     unhealthy_threshold = 3
-    interval            = 30
-    matcher             = "200"
+    interval            = 60
+    matcher             = "200-399"
   }
 }
 

--- a/terraform/telegraf/lb.tf
+++ b/terraform/telegraf/lb.tf
@@ -1,0 +1,85 @@
+resource "aws_lb" "lb" {
+  name               = "telegraf-load-balancer"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.lb_sg.id}"]
+  subnets            = ["${data.aws_subnet_ids.public_subnets.ids}"]
+
+  enable_deletion_protection = false
+}
+
+resource "aws_security_group" "lb_sg" {
+  name        = "telegraf-lb-sg"
+  description = "Allow telegraf traffic into load balancer"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform   = "true"
+    Repo_url    = "${var.repo_url}"
+    Environment = "Prod"
+    Owner       = "relops@mozilla.com"
+  }
+}
+
+resource "aws_lb_target_group" "lb_target_group" {
+  name        = "telegraf-lb-tg"
+  port        = 8086
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${data.aws_vpcs.moz_internal_us_west_2.ids[0]}"
+
+  health_check {
+    path                = "/api/health"
+    port                = 8086
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.lb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+  }
+}
+
+resource "aws_route53_record" "telegraf" {
+  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  name    = "telegraf.relops.mozops.net"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.lb.dns_name}"
+    zone_id                = "${aws_lb.lb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/terraform/telegraf/providers.tf
+++ b/terraform/telegraf/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/terraform/telegraf/resources.tf
+++ b/terraform/telegraf/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/terraform/telegraf/terraform.tfvars
+++ b/terraform/telegraf/terraform.tfvars
@@ -2,7 +2,7 @@ tag_project_name = "telegraf"
 
 app_count = 1
 
-app_image = "telegraf/telegraf:1.10"
+app_image = "961225894672.dkr.ecr.us-west-2.amazonaws.com/telegraf:latest"
 
 fargate_cpu = 512
 

--- a/terraform/telegraf/terraform.tfvars
+++ b/terraform/telegraf/terraform.tfvars
@@ -4,8 +4,20 @@ app_count = 1
 
 app_image = "961225894672.dkr.ecr.us-west-2.amazonaws.com/telegraf:latest"
 
-fargate_cpu = 512
+fargate_cpu = 4096
 
-fargate_memory = 1024
+fargate_memory = 8192
 
 app_port = 8086
+
+influxdb_url = "http://34.216.9.122:8086"
+
+influxdb_db = "relops"
+
+influxdb_user = "relops_wo"
+
+interval = "150s"
+
+medium_interval = "300s"
+
+long_interval = "600s"

--- a/terraform/telegraf/terraform.tfvars
+++ b/terraform/telegraf/terraform.tfvars
@@ -1,0 +1,11 @@
+tag_project_name = "telegraf"
+
+app_count = 1
+
+app_image = "telegraf/telegraf:1.10"
+
+fargate_cpu = 512
+
+fargate_memory = 1024
+
+app_port = 8086

--- a/terraform/telegraf/variables.tf
+++ b/terraform/telegraf/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/telegraf/vars.tf
+++ b/terraform/telegraf/vars.tf
@@ -1,0 +1,19 @@
+variable "app_count" {
+  description = "Number of application instances"
+}
+
+variable "app_image" {
+  description = "Docker Hub slug"
+}
+
+variable "fargate_cpu" {
+  description = "Maximum number of instances in the cluster"
+}
+
+variable "fargate_memory" {
+  description = "Minimum number of instances in the cluster"
+}
+
+variable "app_port" {
+  description = "Port number of application"
+}

--- a/terraform/telegraf/vars.tf
+++ b/terraform/telegraf/vars.tf
@@ -17,3 +17,33 @@ variable "fargate_memory" {
 variable "app_port" {
   description = "Port number of application"
 }
+
+variable "influxdb_url" {
+  description = "InfluxDB host url"
+  default     = "http://influxdb:8086"
+}
+
+variable "influxdb_db" {
+  description = "InfluxDB database name"
+  default     = "default"
+}
+
+variable "influxdb_user" {
+  description = "InfluxDB user name"
+  default     = "admin"
+}
+
+variable "interval" {
+  description = "Metric collection default interval"
+  default     = "60s"
+}
+
+variable "medium_interval" {
+  description = "Metric collection medium interval"
+  default     = "300s"
+}
+
+variable "long_interval" {
+  description = "Metric collection long interval"
+  default     = "600s"
+}


### PR DESCRIPTION
Set up an ECS service running telegraf:
1. to receive influx formatted metrics posts as a relay, and
2. to perform metrics queries through other input plugins.

This is a copy the grafana terraform setup, with the port, container, role, and variables changed. I'm using a container image pushed to ECR. I will add that in a separate PR