### PR TITLE
bitbar devicepool uses larger nodes

### DIFF
--- a/terraform/bitbar-devicepool/compute.tf
+++ b/terraform/bitbar-devicepool/compute.tf
@@ -2,7 +2,7 @@ resource "google_compute_instance" "vm_instance" {
   count = "${var.host_count}"
 
   name         = "bitbar-devicepool-${count.index}"
-  machine_type = "f1-micro"
+  machine_type = "n1-standard-2"
 
   metadata {
     // can take multiple, just separate with "\n"

--- a/terraform/bitbar-devicepool/compute.tf
+++ b/terraform/bitbar-devicepool/compute.tf
@@ -1,3 +1,10 @@
+resource "google_compute_disk" "vm_disk" {
+  name  = "bitbar-devicepool-disk-${count.index}"
+  count = "${var.host_count}"
+  size  = "25"
+  image = "ubuntu-1804-lts"
+}
+
 resource "google_compute_instance" "vm_instance" {
   count = "${var.host_count}"
 
@@ -10,10 +17,8 @@ resource "google_compute_instance" "vm_instance" {
   }
 
   boot_disk {
-    initialize_params {
-      image = "ubuntu-1804-lts"
-      size  = "25"
-    }
+    auto_delete = false
+    source      = "${element(google_compute_disk.vm_disk.*.self_link, count.index)}"
   }
 
   network_interface {

--- a/terraform/bitbar-devicepool/compute.tf
+++ b/terraform/bitbar-devicepool/compute.tf
@@ -12,7 +12,7 @@ resource "google_compute_instance" "vm_instance" {
   boot_disk {
     initialize_params {
       image = "ubuntu-1804-lts"
-      sie   = "25"
+      size  = "25"
     }
   }
 

--- a/terraform/bitbar-devicepool/compute.tf
+++ b/terraform/bitbar-devicepool/compute.tf
@@ -12,6 +12,7 @@ resource "google_compute_instance" "vm_instance" {
   boot_disk {
     initialize_params {
       image = "ubuntu-1804-lts"
+      sie   = "25"
     }
   }
 


### PR DESCRIPTION
- n1-standard-2: 2 CPU, 8 GB RAM
- 25GB spinning disk
  - disks aren't deleted on node deletion (allows resizing without losing the disk)