### PR TITLE
fqdn var, set in config

### DIFF
--- a/terraform/grafana/ecs-cluster.tf
+++ b/terraform/grafana/ecs-cluster.tf
@@ -61,7 +61,8 @@ resource "aws_ecs_task_definition" "app" {
     "environment" : [
       { "name" : "GF_DATABASE_TYPE", "value" : "mysql" },
       { "name" : "GF_DATABASE_HOST", "value" : "${aws_db_instance.mysql.endpoint}" },
-      { "name" : "GF_DATABASE_USER", "value" : "${var.db_username}" }
+      { "name" : "GF_DATABASE_USER", "value" : "${var.db_username}" },
+      { "name" : "GF_SERVER_DOMAIN", "value" : "${var.fqdn}" }
     ],
     "secrets": [
         {

--- a/terraform/grafana/lb.tf
+++ b/terraform/grafana/lb.tf
@@ -74,7 +74,7 @@ resource "aws_lb_listener" "front_end" {
 
 resource "aws_route53_record" "grafana" {
   zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
-  name    = "grafana.relops.mozops.net"
+  name    = "${var.fqdn}"
   type    = "A"
 
   alias {

--- a/terraform/grafana/terraform.tfvars
+++ b/terraform/grafana/terraform.tfvars
@@ -1,8 +1,10 @@
 tag_project_name = "grafana"
 
+fqdn = "grafana.relops.mozops.net"
+
 app_count = 1
 
-app_image = "grafana/grafana:6.1.6"
+app_image = "grafana/grafana:6.2.5"
 
 fargate_cpu = 512
 

--- a/terraform/grafana/vars.tf
+++ b/terraform/grafana/vars.tf
@@ -1,3 +1,7 @@
+variable "fqdn" {
+  description = "Full domain name for dns, load balancer, and https://grafana.com/docs/installation/configuration/#domain"
+}
+
 variable "app_count" {
   description = "Number of application instances"
 }


### PR DESCRIPTION
* upgrade to grafana 6.2.5 (confirmed available on docker hub)
* make the fqdn a variable
* use fqdn to set domain for grafana config (so it can tell us where it is in alerts)