### PR TITLE
grafana: set root_url

### DIFF
--- a/terraform/grafana/ecs-cluster.tf
+++ b/terraform/grafana/ecs-cluster.tf
@@ -62,7 +62,8 @@ resource "aws_ecs_task_definition" "app" {
       { "name" : "GF_DATABASE_TYPE", "value" : "mysql" },
       { "name" : "GF_DATABASE_HOST", "value" : "${aws_db_instance.mysql.endpoint}" },
       { "name" : "GF_DATABASE_USER", "value" : "${var.db_username}" },
-      { "name" : "GF_SERVER_DOMAIN", "value" : "${var.fqdn}" }
+      { "name" : "GF_SERVER_DOMAIN", "value" : "${var.fqdn}" },
+      { "name" : "GF_SERVER_ROOT_URL", "value" : "${var.root_url}"
     ],
     "secrets": [
         {

--- a/terraform/grafana/ecs-cluster.tf
+++ b/terraform/grafana/ecs-cluster.tf
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "app" {
       { "name" : "GF_DATABASE_HOST", "value" : "${aws_db_instance.mysql.endpoint}" },
       { "name" : "GF_DATABASE_USER", "value" : "${var.db_username}" },
       { "name" : "GF_SERVER_DOMAIN", "value" : "${var.fqdn}" },
-      { "name" : "GF_SERVER_ROOT_URL", "value" : "${var.root_url}"
+      { "name" : "GF_SERVER_ROOT_URL", "value" : "${var.root_url}" }
     ],
     "secrets": [
         {

--- a/terraform/grafana/terraform.tfvars
+++ b/terraform/grafana/terraform.tfvars
@@ -2,6 +2,8 @@ tag_project_name = "grafana"
 
 fqdn = "grafana.relops.mozops.net"
 
+root_url = "https://grafana.relops.mozops.net"
+
 app_count = 1
 
 app_image = "grafana/grafana:6.2.5"

--- a/terraform/grafana/vars.tf
+++ b/terraform/grafana/vars.tf
@@ -2,6 +2,10 @@ variable "fqdn" {
   description = "Full domain name for dns, load balancer, and https://grafana.com/docs/installation/configuration/#domain"
 }
 
+variable "root_url" {
+  description = "Path to reach Grafana at, see https://grafana.com/docs/installation/configuration/#root-url"
+}
+
 variable "app_count" {
   description = "Number of application instances"
 }


### PR DESCRIPTION
https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/19 helped, but the URLs in Pagerduty alerts are still wrong:

```
http://grafana.relops.mozops.net:3000/d/eX_tJyuiz/android-queues?fullscreen&edit&tab=alert&panelId=10&orgId=1
```

I think we want to set root_url.