### PR TITLE
Give pytest role read perms for ebs snapshots

### DIFF
--- a/terraform/base/policies/PytestServicesReadOnly.json
+++ b/terraform/base/policies/PytestServicesReadOnly.json
@@ -9,6 +9,8 @@
         "ec2:DescribeFlowLogs",
         "ec2:DescribeInstances",
         "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshotAttribute",
+        "ec2:DescribeSnapshots",
         "ec2:DescribeVolumes",
         "ec2:DescribeVpcs",
         "elasticache:DescribeCacheClusters",


### PR DESCRIPTION
Will allow pytest-services to run it's new "check if EBS snapshots are public" test:
https://github.com/mozilla-services/pytest-services/pull/285

cc @dividehex 