### PR TITLE
Bump vault version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v3.2.0
   hooks:
   - id: check-executables-have-shebangs
   - id: check-json
@@ -9,12 +9,12 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 1.11.0
+  rev: 2.1.4
   hooks:
     - id: shellcheck
 
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.17.0
+  rev: v1.39.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/terraform/vault/task-definitions/vault.json
+++ b/terraform/vault/task-definitions/vault.json
@@ -2,7 +2,7 @@
   {
     "name": "vault",
     "containerName": "vault",
-    "image": "vault:1.4.3",
+    "image": "vault:1.5.3",
     "memory": 6144,
     "linuxParameters": {
       "capabilities": {

--- a/terraform/vault_config/puppet_approle_ids.tf
+++ b/terraform/vault_config/puppet_approle_ids.tf
@@ -22,7 +22,7 @@ resource "vault_approle_auth_backend_role" "approle_puppet_roles" {
   backend               = vault_auth_backend.approle.path
   role_name             = each.value
   secret_id_bound_cidrs = ["10.49.0.0/16", "10.51.0.0/16"]
-  token_bound_cidrs     = ["10.49.56.0/22", "10.51.56.0/22"]
+  token_bound_cidrs     = ["10.49.0.0/16", "10.51.0.0/16"]
   token_ttl             = 3600  # 6 hours
   token_max_ttl         = 86400 # 24 hours
   token_policies        = ["puppet_role_${each.value}"]


### PR DESCRIPTION
This PR does the following:
* updates pre-commit checks to latest versions
* expands puppet approle boundaries (this is a noop since the approles were originally created with these boundaries)
* bumps the vault docker image version to the latest (v1.5.3)