### PR TITLE
Upgrade Terraform code to v0.13.x compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.3.0
   hooks:
   - id: check-executables-have-shebangs
   - id: check-json
@@ -14,7 +14,7 @@ repos:
     - id: shellcheck
 
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.39.0
+  rev: v1.45.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         VAULT_ADDR="https://127.0.0.1:8200"
         VSPHERE_PASSWORD=empty
 install:
-  - curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip"
+  - curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip"
   - unzip /tmp/terraform.zip -d "$HOME/bin"
   - terraform --version
   - shellcheck --version

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
 For more details, please read the
-[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
 For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.

--- a/terraform/base/backend.tf
+++ b/terraform/base/backend.tf
@@ -6,3 +6,4 @@ terraform {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/base/cloudtrail.tf
+++ b/terraform/base/cloudtrail.tf
@@ -12,3 +12,4 @@ resource "aws_cloudtrail" "cloudtrail" {
     bug  = "1531162"
   }
 }
+

--- a/terraform/base/endpoints.tf
+++ b/terraform/base/endpoints.tf
@@ -1,10 +1,10 @@
 resource "aws_vpc_endpoint" "kms" {
-  vpc_id            = "${module.vpc_moz_internal_us_west_2.vpc_id}"
+  vpc_id            = module.vpc_moz_internal_us_west_2.vpc_id
   service_name      = "com.amazonaws.us-west-2.kms"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${aws_security_group.kms_sg.id}",
+    aws_security_group.kms_sg.id,
   ]
 
   subnet_ids = module.vpc_moz_internal_us_west_2.public_subnets
@@ -15,7 +15,7 @@ resource "aws_vpc_endpoint" "kms" {
 resource "aws_security_group" "kms_sg" {
   name        = "kms-sg"
   description = "Allow traffic to kms endpoint"
-  vpc_id      = "${module.vpc_moz_internal_us_west_2.vpc_id}"
+  vpc_id      = module.vpc_moz_internal_us_west_2.vpc_id
 
   ingress {
     from_port   = 443
@@ -26,7 +26,7 @@ resource "aws_security_group" "kms_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }

--- a/terraform/base/iam_password_policy.tf
+++ b/terraform/base/iam_password_policy.tf
@@ -7,3 +7,4 @@ resource "aws_iam_account_password_policy" "pw_policy" {
   require_symbols                = true
   allow_users_to_change_password = true
 }
+

--- a/terraform/base/outputs.tf
+++ b/terraform/base/outputs.tf
@@ -1,32 +1,34 @@
 # VPCs
 output "vpc_us_east_1_id" {
   description = "The ID of the us-east-1 VPC"
-  value       = "${module.vpc_moz_internal_us_east_1.vpc_id}"
+  value       = module.vpc_moz_internal_us_east_1.vpc_id
 }
 
 output "vpc_us_west_2_id" {
   description = "The ID of the us-west-2 VPC"
-  value       = "${module.vpc_moz_internal_us_west_2.vpc_id}"
+  value       = module.vpc_moz_internal_us_west_2.vpc_id
 }
 
 output "us_east_1_public_subnets" {
   description = "List of IDs of us-east-1 public subnets"
-  value       = ["${module.vpc_moz_internal_us_east_1.public_subnets}"]
+  value       = [module.vpc_moz_internal_us_east_1.public_subnets]
 }
 
 output "us_west_2_public_subnets" {
   description = "List of IDs of us-west-2 public subnets"
-  value       = ["${module.vpc_moz_internal_us_west_2.public_subnets}"]
+  value       = [module.vpc_moz_internal_us_west_2.public_subnets]
 }
 
 // see https://mana.mozilla.org/wiki/display/IT/Mozilla+VPN#MozillaVPN-RelevantIPs
 output "mozilla_vpn_netblocks" {
   description = "List of Mozilla corporate VPN netblocks"
 
-  value = ["63.245.208.132/32",
+  value = [
+    "63.245.208.132/32",
     "63.245.208.133/32",
     "63.245.210.132/32",
     "63.245.210.133/32",
     "185.155.182.210/32",
   ]
 }
+

--- a/terraform/base/pytest-services.tf
+++ b/terraform/base/pytest-services.tf
@@ -14,11 +14,12 @@ data "aws_iam_policy_document" "pytest_assume_role_policy" {
 
 resource "aws_iam_role_policy" "pytest_role_policy" {
   name   = "PytestServices"
-  role   = "${aws_iam_role.pytest_role.id}"
-  policy = "${file("policies/PytestServicesReadOnly.json")}"
+  role   = aws_iam_role.pytest_role.id
+  policy = file("policies/PytestServicesReadOnly.json")
 }
 
 resource "aws_iam_role" "pytest_role" {
   name               = "PytestServices"
-  assume_role_policy = "${data.aws_iam_policy_document.pytest_assume_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.pytest_assume_role_policy.json
 }
+

--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -3,3 +3,4 @@
 resource "aws_route53_zone" "relops_mozops_net_public" {
   name = "relops.mozops.net"
 }
+

--- a/terraform/base/tf_s3_state_bucket.tf
+++ b/terraform/base/tf_s3_state_bucket.tf
@@ -8,8 +8,9 @@ resource "aws_s3_bucket" "state_bucket" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_base.tf
+++ b/terraform/base/tf_state_lock_base.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_base" {
   tags = {
     Name        = "Base Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_bitbar-devicepool.tf
+++ b/terraform/base/tf_state_lock_bitbar-devicepool.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_bitbar-devicepool" {
   tags = {
     Name        = "bitbar-devicepool Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_maas.tf
+++ b/terraform/base/tf_state_lock_maas.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_maas" {
   tags = {
     Name        = "maas Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_puppetagain_ca_codecommit.tf
+++ b/terraform/base/tf_state_lock_puppetagain_ca_codecommit.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_puppetagain_ca_codecommit" {
   tags = {
     Name        = "puppetagain_ca_codecommit Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_ronin-puppet-package-repo.tf
+++ b/terraform/base/tf_state_lock_ronin-puppet-package-repo.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_ronin-puppet-package-repo" {
   tags = {
     Name        = "ronin-puppet-package-repo Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_sops_codecommit.tf
+++ b/terraform/base/tf_state_lock_sops_codecommit.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_sops_codecommit" {
   tags = {
     Name        = "sops_codecommit Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_taskqueue-influxdb-metrics.tf
+++ b/terraform/base/tf_state_lock_taskqueue-influxdb-metrics.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_taskqueue-influxdb-metrics" {
   tags = {
     Name        = "taskqueue-influxdb-metrics Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_telegraf.tf
+++ b/terraform/base/tf_state_lock_telegraf.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_telegraf" {
   tags = {
     Name        = "telegraf Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_vault.tf
+++ b/terraform/base/tf_state_lock_vault.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_vault" {
   tags = {
     Name        = "vault Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_vault_config.tf
+++ b/terraform/base/tf_state_lock_vault_config.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_vault_config" {
   tags = {
     Name        = "vault_config Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/tf_state_lock_vpns.tf
+++ b/terraform/base/tf_state_lock_vpns.tf
@@ -12,8 +12,9 @@ resource "aws_dynamodb_table" "tf_state_lock_vpns" {
   tags = {
     Name        = "vpns Terraform State Lock Table"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
+

--- a/terraform/base/versions.tf
+++ b/terraform/base/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/base/versions.tf
+++ b/terraform/base/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/base/vpc.tf
+++ b/terraform/base/vpc.tf
@@ -2,7 +2,7 @@ module "vpc_moz_internal_us_east_1" {
   source = "terraform-aws-modules/vpc/aws"
 
   providers = {
-    aws = "aws.us-east-1"
+    aws = aws.us-east-1
   }
 
   name = "moz-internal-us-east-1"
@@ -23,7 +23,7 @@ module "vpc_moz_internal_us_east_1" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -33,7 +33,7 @@ resource "aws_route53_zone" "use1" {
   name = "use1.relops"
 
   vpc {
-    vpc_id     = "${module.vpc_moz_internal_us_east_1.vpc_id}"
+    vpc_id     = module.vpc_moz_internal_us_east_1.vpc_id
     vpc_region = "us-east-1"
   }
 }
@@ -42,7 +42,7 @@ resource "aws_route53_zone" "use1_arpa" {
   name = "6.191.10.in-addr.arpa."
 
   vpc {
-    vpc_id     = "${module.vpc_moz_internal_us_east_1.vpc_id}"
+    vpc_id     = module.vpc_moz_internal_us_east_1.vpc_id
     vpc_region = "us-east-1"
   }
 }
@@ -51,7 +51,7 @@ module "vpc_moz_internal_us_west_2" {
   source = "terraform-aws-modules/vpc/aws"
 
   providers = {
-    aws = "aws.us-west-2"
+    aws = aws.us-west-2
   }
 
   name = "moz-internal-us-west-2"
@@ -74,7 +74,7 @@ module "vpc_moz_internal_us_west_2" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
@@ -84,7 +84,7 @@ resource "aws_route53_zone" "usw2" {
   name = "usw2.relops"
 
   vpc {
-    vpc_id     = "${module.vpc_moz_internal_us_west_2.vpc_id}"
+    vpc_id     = module.vpc_moz_internal_us_west_2.vpc_id
     vpc_region = "us-west-2"
   }
 }
@@ -93,7 +93,8 @@ resource "aws_route53_zone" "usw2_arpa" {
   name = "7.191.10.in-addr.arpa."
 
   vpc {
-    vpc_id     = "${module.vpc_moz_internal_us_west_2.vpc_id}"
+    vpc_id     = module.vpc_moz_internal_us_west_2.vpc_id
     vpc_region = "us-west-2"
   }
 }
+

--- a/terraform/bitbar-devicepool/backend.tf
+++ b/terraform/bitbar-devicepool/backend.tf
@@ -6,3 +6,4 @@ terraform {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/bitbar-devicepool/compute.tf
+++ b/terraform/bitbar-devicepool/compute.tf
@@ -1,39 +1,39 @@
 resource "google_compute_disk" "vm_disk" {
   name  = "bitbar-devicepool-disk-${count.index}"
-  count = "${var.host_count}"
+  count = var.host_count
   size  = "25"
   image = "ubuntu-1804-lts"
 }
 
 resource "google_compute_instance" "vm_instance" {
-  count = "${var.host_count}"
+  count = var.host_count
 
   name         = "bitbar-devicepool-${count.index}"
   machine_type = "n1-standard-2"
 
   metadata = {
-    // can take multiple, just separate with "\n"
+    # can take multiple, just separate with "\n"
     sshKeys = "${var.ssh_user}:${var.ssh_key}"
   }
 
   boot_disk {
     auto_delete = false
-    source      = "${element(google_compute_disk.vm_disk.*.self_link, count.index)}"
+    source      = element(google_compute_disk.vm_disk.*.self_link, count.index)
   }
 
   network_interface {
     # A default network is created for all GCP projects
-    network = "${google_compute_network.bitbar-net.name}"
+    network = google_compute_network.bitbar-net.name
 
     access_config {
-      nat_ip = "${element(google_compute_address.ip_address.*.address, count.index)}"
+      nat_ip = element(google_compute_address.ip_address.*.address, count.index)
     }
   }
 }
 
 resource "google_compute_firewall" "devicepool-firewall" {
   name    = "devicepool-firewall"
-  network = "${google_compute_network.bitbar-net.name}"
+  network = google_compute_network.bitbar-net.name
 
   allow {
     protocol = "icmp"
@@ -43,8 +43,7 @@ resource "google_compute_firewall" "devicepool-firewall" {
     protocol = "tcp"
     ports    = ["22"]
   }
-
-  // restricted to vpn
+  # restricted to vpn
   source_ranges = data.terraform_remote_state.base.outputs.mozilla_vpn_netblocks
 }
 
@@ -53,16 +52,17 @@ resource "google_compute_network" "bitbar-net" {
 }
 
 resource "google_compute_address" "ip_address" {
-  count = "${var.host_count}"
+  count = var.host_count
   name  = "devicepool-ip-${count.index}"
 }
 
 resource "aws_route53_record" "devicepool" {
-  count = "${var.host_count}"
+  count = var.host_count
 
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
   name    = "devicepool-${count.index}.relops.mozops.net"
   type    = "A"
   ttl     = "3600"
-  records = ["${element(google_compute_address.ip_address.*.address, count.index)}"]
+  records = [element(google_compute_address.ip_address.*.address, count.index)]
 }
+

--- a/terraform/bitbar-devicepool/datasources.tf
+++ b/terraform/bitbar-devicepool/datasources.tf
@@ -12,3 +12,4 @@ data "terraform_remote_state" "base" {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/bitbar-devicepool/gce-providers.tf
+++ b/terraform/bitbar-devicepool/gce-providers.tf
@@ -4,3 +4,4 @@ provider "google" {
   region  = "us-west1"
   zone    = "us-west1-b"
 }
+

--- a/terraform/bitbar-devicepool/local-variables.tf
+++ b/terraform/bitbar-devicepool/local-variables.tf
@@ -10,3 +10,4 @@ variable "host_count" {
   description = "Number of bitbar-devicepool hosts to create."
   default     = "1"
 }
+

--- a/terraform/bitbar-devicepool/versions.tf
+++ b/terraform/bitbar-devicepool/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/bitbar-devicepool/versions.tf
+++ b/terraform/bitbar-devicepool/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }

--- a/terraform/maas/versions.tf
+++ b/terraform/maas/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/maas/versions.tf
+++ b/terraform/maas/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    vsphere = {
+      source = "hashicorp/vsphere"
+    }
+  }
 }

--- a/terraform/puppetagain_ca_codecommit/backend.tf
+++ b/terraform/puppetagain_ca_codecommit/backend.tf
@@ -6,3 +6,4 @@ terraform {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/puppetagain_ca_codecommit/codecommit.tf
+++ b/terraform/puppetagain_ca_codecommit/codecommit.tf
@@ -4,5 +4,6 @@ resource "aws_codecommit_repository" "puppetagain_ca" {
 }
 
 output "puppetagain_ca_clone_url_ssh" {
-  value = "${aws_codecommit_repository.puppetagain_ca.clone_url_ssh}"
+  value = aws_codecommit_repository.puppetagain_ca.clone_url_ssh
 }
+

--- a/terraform/puppetagain_ca_codecommit/versions.tf
+++ b/terraform/puppetagain_ca_codecommit/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/puppetagain_ca_codecommit/versions.tf
+++ b/terraform/puppetagain_ca_codecommit/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -3,9 +3,10 @@ locals {
   common_tags = {
     # Always true; it's why we're here
     terraform        = "true"
-    project_name     = "${var.tag_project_name}"
-    production_state = "${var.tag_production_state}"
-    owner_email      = "${var.tag_owner_email}"
+    project_name     = var.tag_project_name
+    production_state = var.tag_production_state
+    owner_email      = var.tag_owner_email
     source_repo_url  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
   }
 }
+

--- a/terraform/ronin-puppet-package-repo/backend.tf
+++ b/terraform/ronin-puppet-package-repo/backend.tf
@@ -6,3 +6,4 @@ terraform {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/ronin-puppet-package-repo/s3.tf
+++ b/terraform/ronin-puppet-package-repo/s3.tf
@@ -17,12 +17,13 @@ resource "aws_s3_bucket" "package_bucket" {
 }
 POLICY
 
+
   versioning {
     enabled = true
   }
 
   logging {
-    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_bucket = aws_s3_bucket.log_bucket.id
     target_prefix = "log/"
   }
 
@@ -42,8 +43,9 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_object" "index" {
-  bucket = "${aws_s3_bucket.package_bucket.id}"
+  bucket = aws_s3_bucket.package_bucket.id
   key    = "index.html"
   source = "files/index.html"
-  etag   = "${md5(file("files/index.html"))}"
+  etag   = filemd5("files/index.html")
 }
+

--- a/terraform/ronin-puppet-package-repo/versions.tf
+++ b/terraform/ronin-puppet-package-repo/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/ronin-puppet-package-repo/versions.tf
+++ b/terraform/ronin-puppet-package-repo/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/sops_codecommit/backend.tf
+++ b/terraform/sops_codecommit/backend.tf
@@ -6,3 +6,4 @@ terraform {
     region         = "us-west-2"
   }
 }
+

--- a/terraform/sops_codecommit/codecommit.tf
+++ b/terraform/sops_codecommit/codecommit.tf
@@ -7,5 +7,6 @@ resource "aws_codecommit_repository" "sop" {
 }
 
 output "sops_clone_url_ssh" {
-  value = "${aws_codecommit_repository.sop.clone_url_ssh}"
+  value = aws_codecommit_repository.sop.clone_url_ssh
 }
+

--- a/terraform/sops_codecommit/kms.tf
+++ b/terraform/sops_codecommit/kms.tf
@@ -14,7 +14,7 @@ resource "aws_kms_key" "sops_shamir_usw2_key" {
 resource "aws_kms_alias" "sops_shamir_usw2_alias" {
   provider      = aws.us-west-2
   name          = "alias/relops_sops_usw2"
-  target_key_id = "${aws_kms_key.sops_shamir_usw2_key.key_id}"
+  target_key_id = aws_kms_key.sops_shamir_usw2_key.key_id
 
   lifecycle {
     prevent_destroy = true
@@ -37,7 +37,7 @@ resource "aws_kms_key" "sops_shamir_use1_key" {
 resource "aws_kms_alias" "sops_shamir_use1_alias" {
   provider      = aws.us-east-1
   name          = "alias/relops_sops_use1"
-  target_key_id = "${aws_kms_key.sops_shamir_use1_key.key_id}"
+  target_key_id = aws_kms_key.sops_shamir_use1_key.key_id
 
   lifecycle {
     prevent_destroy = true

--- a/terraform/sops_codecommit/versions.tf
+++ b/terraform/sops_codecommit/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/sops_codecommit/versions.tf
+++ b/terraform/sops_codecommit/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/taskqueue-influxdb-metrics/cloudwatch.tf
+++ b/terraform/taskqueue-influxdb-metrics/cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_event_rule" "tick_1m" {
 }
 
 resource "aws_cloudwatch_event_target" "lambda_trigger" {
-  rule      = "${aws_cloudwatch_event_rule.tick_1m.name}"
+  rule      = aws_cloudwatch_event_rule.tick_1m.name
   target_id = "lambda_trigger"
-  arn       = "${aws_lambda_function.bitbar_influx_logger.arn}"
+  arn       = aws_lambda_function.bitbar_influx_logger.arn
 }

--- a/terraform/taskqueue-influxdb-metrics/lambda.tf
+++ b/terraform/taskqueue-influxdb-metrics/lambda.tf
@@ -18,8 +18,8 @@ EOF
 
 resource "aws_iam_policy_attachment" "secretsmanager_to_influx" {
   name       = "secretsmanager_to_influx"
-  roles      = ["${aws_iam_role.iam_for_lambda.name}"]
-  policy_arn = "${aws_iam_policy.secretsmanager-influx.arn}"
+  roles      = [aws_iam_role.iam_for_lambda.name]
+  policy_arn = aws_iam_policy.secretsmanager-influx.arn
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -47,7 +47,7 @@ EOF
 resource "aws_lambda_function" "bitbar_influx_logger" {
   filename         = "function.zip"
   function_name    = "bitbar_influx_logger"
-  role             = "${aws_iam_role.iam_for_lambda.arn}"
+  role             = aws_iam_role.iam_for_lambda.arn
   handler          = "function.lambda_handler"
   source_code_hash = filebase64sha256("function.zip")
   runtime          = "python3.6"
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "bitbar_influx_logger" {
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.bitbar_influx_logger.function_name}"
+  function_name = aws_lambda_function.bitbar_influx_logger.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.tick_1m.arn}"
+  source_arn    = aws_cloudwatch_event_rule.tick_1m.arn
 }

--- a/terraform/taskqueue-influxdb-metrics/versions.tf
+++ b/terraform/taskqueue-influxdb-metrics/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/taskqueue-influxdb-metrics/versions.tf
+++ b/terraform/taskqueue-influxdb-metrics/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/telegraf/certificates.tf
+++ b/terraform/telegraf/certificates.tf
@@ -8,14 +8,14 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }

--- a/terraform/telegraf/cloudwatch-log-group.tf
+++ b/terraform/telegraf/cloudwatch-log-group.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_log_group" "telegraf" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }

--- a/terraform/telegraf/datasources.tf
+++ b/terraform/telegraf/datasources.tf
@@ -1,6 +1,6 @@
 # Look up usw2 vpc
 data "aws_vpcs" "moz_internal_us_west_2" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name = "moz-internal-us-west-2"

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -106,22 +106,22 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "main" {
-  name = "telegraf"
-  cluster = "${aws_ecs_cluster.main.id}"
+  name            = "telegraf"
+  cluster         = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.app.arn}"
-  desired_count = "${var.app_count}"
-  launch_type = "FARGATE"
+  desired_count   = "${var.app_count}"
+  launch_type     = "FARGATE"
 
   network_configuration {
-    subnets = data.aws_subnet_ids.public_subnets.ids
-    security_groups = ["${aws_security_group.ecs_public_sg.id}"]
+    subnets          = data.aws_subnet_ids.public_subnets.ids
+    security_groups  = ["${aws_security_group.ecs_public_sg.id}"]
     assign_public_ip = true
   }
 
   load_balancer {
     target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
-    container_name = "telegraf"
-    container_port = 8086
+    container_name   = "telegraf"
+    container_port   = 8086
   }
 
   depends_on = ["aws_lb_listener.front_end", "aws_ecs_task_definition.app"]

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -38,12 +38,12 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
-  role = "${aws_iam_role.ecs-task-exec-role.name}"
+  role       = "${aws_iam_role.ecs-task-exec-role.name}"
   policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
 }
 
 resource "aws_iam_policy" "ecr_policy" {
-  name = "telegraf-ECRAllow"
+  name        = "telegraf-ECRAllow"
   description = "Allow telegraf to read from ecr"
 
   policy = <<EOF

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
 
 resource "aws_iam_role" "ecs-task-exec-role" {
   name               = "telegraf-ecs-task-exec-role"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-task-assume-role-policy.json
 }
 
 resource "aws_iam_policy" "secrets_read_policy" {
@@ -38,8 +38,8 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
-  role       = "${aws_iam_role.ecs-task-exec-role.name}"
-  policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
+  role       = aws_iam_role.ecs-task-exec-role.name
+  policy_arn = aws_iam_policy.secrets_read_policy.arn
 }
 
 resource "aws_iam_policy" "ecr_policy" {
@@ -68,6 +68,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_ecr_policy" {
-  role       = "${aws_iam_role.ecs-task-exec-role.name}"
-  policy_arn = "${aws_iam_policy.ecr_policy.arn}"
+  role       = aws_iam_role.ecs-task-exec-role.name
+  policy_arn = aws_iam_policy.ecr_policy.arn
 }

--- a/terraform/telegraf/lb.tf
+++ b/terraform/telegraf/lb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "lb" {
   name               = "telegraf-load-balancer"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = ["${aws_security_group.lb_sg.id}"]
+  security_groups    = [aws_security_group.lb_sg.id]
   subnets            = data.aws_subnet_ids.public_subnets.ids
 
   enable_deletion_protection = false
@@ -28,8 +28,8 @@ resource "aws_security_group" "lb_sg" {
   }
 
   ingress {
-    from_port   = "${var.webhook_port}"
-    to_port     = "${var.webhook_port}"
+    from_port   = var.webhook_port
+    to_port     = var.webhook_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -43,7 +43,7 @@ resource "aws_security_group" "lb_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -51,14 +51,14 @@ resource "aws_security_group" "lb_sg" {
 
 resource "aws_lb_target_group" "lb_target_group" {
   name        = "telegraf-lb-tg"
-  port        = "${var.app_port}"
+  port        = var.app_port
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = join(", ", data.aws_vpcs.moz_internal_us_west_2.ids)
 
   health_check {
     path                = "/ping"
-    port                = "${var.app_port}"
+    port                = var.app_port
     healthy_threshold   = 3
     unhealthy_threshold = 3
     interval            = 60
@@ -68,46 +68,46 @@ resource "aws_lb_target_group" "lb_target_group" {
 
 resource "aws_lb_target_group" "lb_target_group2" {
   name        = "telegraf-lb-tg2"
-  port        = "${var.webhook_port}"
+  port        = var.webhook_port
   protocol    = "HTTPS"
   target_type = "ip"
   vpc_id      = join(", ", data.aws_vpcs.moz_internal_us_west_2.ids)
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.lb.arn}"
+  load_balancer_arn = aws_lb.lb.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = aws_acm_certificate_validation.cert.certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+    target_group_arn = aws_lb_target_group.lb_target_group.arn
   }
 }
 
 resource "aws_lb_listener" "front_end2" {
-  load_balancer_arn = "${aws_lb.lb.arn}"
-  port              = "${var.webhook_port}"
+  load_balancer_arn = aws_lb.lb.arn
+  port              = var.webhook_port
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = aws_acm_certificate_validation.cert.certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_target_group2.arn}"
+    target_group_arn = aws_lb_target_group.lb_target_group2.arn
   }
 }
 
 resource "aws_route53_record" "telegraf" {
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
   name    = "telegraf.relops.mozops.net"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.lb.dns_name}"
-    zone_id                = "${aws_lb.lb.zone_id}"
+    name                   = aws_lb.lb.dns_name
+    zone_id                = aws_lb.lb.zone_id
     evaluate_target_health = true
   }
 }

--- a/terraform/telegraf/versions.tf
+++ b/terraform/telegraf/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,7 +8,6 @@ variable "region" {
 
 variable "tag_project_name" {
   description = "Name of the project; should match dir name"
-
   # No default; must be set in terraform.tfvars
 }
 
@@ -31,3 +30,4 @@ variable "repo_url" {
   description = "A link to this github repo"
   default     = "https://github.com/mozilla-platform-ops/relops_cloud"
 }
+

--- a/terraform/vault/certificates.tf
+++ b/terraform/vault/certificates.tf
@@ -8,14 +8,14 @@ resource "aws_acm_certificate" "vault_cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
-  records = ["${aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
+  records = [aws_acm_certificate.vault_cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.vault_cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.vault_cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }

--- a/terraform/vault/datasources.tf
+++ b/terraform/vault/datasources.tf
@@ -1,6 +1,6 @@
 # Look up usw2 vpc
 data "aws_vpcs" "moz_internal_us_west_2" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name = "moz-internal-us-west-2"

--- a/terraform/vault/dynamodb.tf
+++ b/terraform/vault/dynamodb.tf
@@ -14,18 +14,17 @@ resource "aws_dynamodb_table" "dynamodb-table" {
     type = "S"
   }
 
-  tags = "${merge(
-    local.common_tags,
+  tags = merge(local.common_tags,
     map(
       "Name", "vault-dynamodb-table"
     )
-  )}"
+  )
 }
 
 data "aws_iam_policy_document" "vault_dynamodb_access" {
   statement {
     effect    = "Allow"
-    resources = ["${aws_dynamodb_table.dynamodb-table.arn}"]
+    resources = [aws_dynamodb_table.dynamodb-table.arn]
 
     actions = [
       "dynamodb:DescribeLimits",
@@ -51,10 +50,10 @@ data "aws_iam_policy_document" "vault_dynamodb_access" {
 
 resource "aws_iam_policy" "vault_dynamodb_policy" {
   name   = "Vault-DynamoDB-Policy"
-  policy = "${data.aws_iam_policy_document.vault_dynamodb_access.json}"
+  policy = data.aws_iam_policy_document.vault_dynamodb_access.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-instance-dynamodb-role-attachment" {
-  role       = "${aws_iam_role.ecs-task-role.name}"
-  policy_arn = "${aws_iam_policy.vault_dynamodb_policy.arn}"
+  role       = aws_iam_role.ecs-task-role.name
+  policy_arn = aws_iam_policy.vault_dynamodb_policy.arn
 }

--- a/terraform/vault/ecs-cluster.tf
+++ b/terraform/vault/ecs-cluster.tf
@@ -1,12 +1,11 @@
 resource "aws_ecs_cluster" "vault" {
   name = "vault"
 
-  tags = "${merge(
-    local.common_tags,
+  tags = merge(local.common_tags,
     map(
       "Name", "vault"
     )
-  )}"
+  )
 }
 
 resource "aws_security_group" "ec2_vault_instance_sg" {
@@ -23,7 +22,7 @@ resource "aws_security_group" "ec2_vault_instance_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -31,29 +30,29 @@ resource "aws_security_group" "ec2_vault_instance_sg" {
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {
   name_prefix          = "ecs-vault-launch-configuration-"
-  image_id             = "${var.ecs_ami}"
-  instance_type        = "${var.instance_type}"
-  iam_instance_profile = "${aws_iam_instance_profile.ecs-instance-profile.id}"
+  image_id             = var.ecs_ami
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_instance_profile.ecs-instance-profile.id
 
   lifecycle {
     create_before_destroy = true
   }
 
-  security_groups             = ["${aws_security_group.ec2_vault_instance_sg.id}"]
+  security_groups             = [aws_security_group.ec2_vault_instance_sg.id]
   associate_public_ip_address = "true"
 
   key_name = "relops_common"
 
-  user_data = "${file("userdata/ecs-userdata.sh")}"
+  user_data = file("userdata/ecs-userdata.sh")
 }
 
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   name                 = "ecs-vault-autoscaling-group"
-  max_size             = "${var.max_instance_size}"
-  min_size             = "${var.min_instance_size}"
-  desired_capacity     = "${var.desired_capacity}"
+  max_size             = var.max_instance_size
+  min_size             = var.min_instance_size
+  desired_capacity     = var.desired_capacity
   vpc_zone_identifier  = data.aws_subnet_ids.public_subnets.ids
-  launch_configuration = "${aws_launch_configuration.ecs-launch-configuration.name}"
+  launch_configuration = aws_launch_configuration.ecs-launch-configuration.name
   health_check_type    = "EC2"
   termination_policies = ["OldestInstance"]
 }

--- a/terraform/vault/ecs-instance-role.tf
+++ b/terraform/vault/ecs-instance-role.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "ecs-instance-role" {
   name               = "ecs-instance-role"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-instance-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-instance-policy.json
 }
 
 data "aws_iam_policy_document" "ecs-instance-policy" {
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "ecs-instance-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
-  role       = "${aws_iam_role.ecs-instance-role.name}"
+  role       = aws_iam_role.ecs-instance-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
   name = "ecs-instance-profile"
   path = "/"
-  role = "${aws_iam_role.ecs-instance-role.id}"
+  role = aws_iam_role.ecs-instance-role.id
 }

--- a/terraform/vault/ecs-service-role.tf
+++ b/terraform/vault/ecs-service-role.tf
@@ -1,11 +1,11 @@
 resource "aws_iam_role" "ecs-service-role" {
   name               = "ecs-service-role"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-service-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-service-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-service-role-attachment" {
-  role       = "${aws_iam_role.ecs-service-role.name}"
+  role       = aws_iam_role.ecs-service-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 

--- a/terraform/vault/ecs-service.tf
+++ b/terraform/vault/ecs-service.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "ecs_vault_public_sg" {
     from_port       = 8200
     to_port         = 8200
     protocol        = "tcp"
-    security_groups = ["${aws_security_group.vault_lb_sg.id}"]
+    security_groups = [aws_security_group.vault_lb_sg.id]
   }
 
   ingress {
@@ -33,7 +33,7 @@ resource "aws_security_group" "ecs_vault_public_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -41,18 +41,18 @@ resource "aws_security_group" "ecs_vault_public_sg" {
 
 resource "aws_ecs_service" "vault" {
   name                               = "vault"
-  cluster                            = "${aws_ecs_cluster.vault.id}"
-  task_definition                    = "${aws_ecs_task_definition.vault.arn}"
+  cluster                            = aws_ecs_cluster.vault.id
+  task_definition                    = aws_ecs_task_definition.vault.arn
   scheduling_strategy                = "DAEMON"
   deployment_minimum_healthy_percent = 50
 
   network_configuration {
     subnets         = data.aws_subnet_ids.public_subnets.ids
-    security_groups = ["${aws_security_group.ecs_vault_public_sg.id}"]
+    security_groups = [aws_security_group.ecs_vault_public_sg.id]
   }
 
   load_balancer {
-    target_group_arn = "${aws_lb_target_group.vault_lb_target_group.arn}"
+    target_group_arn = aws_lb_target_group.vault_lb_target_group.arn
     container_name   = "vault"
     container_port   = 8200
   }

--- a/terraform/vault/ecs-task-def.tf
+++ b/terraform/vault/ecs-task-def.tf
@@ -1,13 +1,13 @@
 resource "aws_ecs_task_definition" "vault" {
   family                   = "vault"
-  container_definitions    = "${file("task-definitions/vault.json")}"
+  container_definitions    = file("task-definitions/vault.json")
   requires_compatibilities = ["EC2"]
   network_mode             = "awsvpc"
-  task_role_arn            = "${aws_iam_role.ecs-task-role.arn}"
+  task_role_arn            = aws_iam_role.ecs-task-role.arn
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }

--- a/terraform/vault/ecs-task-role.tf
+++ b/terraform/vault/ecs-task-role.tf
@@ -11,5 +11,5 @@ data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
 
 resource "aws_iam_role" "ecs-task-role" {
   name               = "ecs-task-role"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-task-assume-role-policy.json
 }

--- a/terraform/vault/kms_key.tf
+++ b/terraform/vault/kms_key.tf
@@ -19,10 +19,10 @@ data "aws_iam_policy_document" "vault-kms-unseal" {
 
 resource "aws_iam_policy" "vault-kms-unseal" {
   name   = "Vault-KMS-Unseal"
-  policy = "${data.aws_iam_policy_document.vault-kms-unseal.json}"
+  policy = data.aws_iam_policy_document.vault-kms-unseal.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-instance-kms-role-attachment" {
-  role       = "${aws_iam_role.ecs-task-role.name}"
-  policy_arn = "${aws_iam_policy.vault-kms-unseal.arn}"
+  role       = aws_iam_role.ecs-task-role.name
+  policy_arn = aws_iam_policy.vault-kms-unseal.arn
 }

--- a/terraform/vault/lb.tf
+++ b/terraform/vault/lb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "vault" {
   name               = "vault-load-balancer"
   internal           = true
   load_balancer_type = "application"
-  security_groups    = ["${aws_security_group.vault_lb_sg.id}"]
+  security_groups    = [aws_security_group.vault_lb_sg.id]
   subnets            = data.aws_subnet_ids.public_subnets.ids
 
   enable_deletion_protection = false
@@ -22,7 +22,7 @@ resource "aws_security_group" "vault_lb_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -46,26 +46,26 @@ resource "aws_lb_target_group" "vault_lb_target_group" {
 }
 
 resource "aws_lb_listener" "vault_firont_end" {
-  load_balancer_arn = "${aws_lb.vault.arn}"
+  load_balancer_arn = aws_lb.vault.arn
   port              = "8200"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = aws_acm_certificate_validation.cert.certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.vault_lb_target_group.arn}"
+    target_group_arn = aws_lb_target_group.vault_lb_target_group.arn
   }
 }
 
 resource "aws_route53_record" "vault" {
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
   name    = "vault.relops.mozops.net"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.vault.dns_name}"
-    zone_id                = "${aws_lb.vault.zone_id}"
+    name                   = aws_lb.vault.dns_name
+    zone_id                = aws_lb.vault.zone_id
     evaluate_target_health = true
   }
 }

--- a/terraform/vault/versions.tf
+++ b/terraform/vault/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/vault/versions.tf
+++ b/terraform/vault/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/vault/versions.tf
+++ b/terraform/vault/versions.tf
@@ -1,8 +1,4 @@
+
 terraform {
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
-  required_version = ">= 0.13"
+  required_version = ">= 0.12"
 }

--- a/terraform/vault_config/versions.tf
+++ b/terraform/vault_config/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/vault_config/versions.tf
+++ b/terraform/vault_config/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    vault = {
+      source = "hashicorp/vault"
+    }
+  }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/terraform/vpns/use1.tf
+++ b/terraform/vpns/use1.tf
@@ -1,17 +1,17 @@
 resource "aws_vpn_gateway" "vpn_gw_use1" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
 
   tags = {
     Name        = "USE1 VPN Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_customer_gateway" "cgw_use1_mdc1" {
-  provider   = "aws.us-east-1"
+  provider   = aws.us-east-1
   bgp_asn    = 65048
   ip_address = "63.245.208.251"
   type       = "ipsec.1"
@@ -19,14 +19,14 @@ resource "aws_customer_gateway" "cgw_use1_mdc1" {
   tags = {
     Name        = "MDC1 Customer Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_customer_gateway" "cgw_use1_mdc2" {
-  provider   = "aws.us-east-1"
+  provider   = aws.us-east-1
   bgp_asn    = 65050
   ip_address = "63.245.210.251"
   type       = "ipsec.1"
@@ -34,44 +34,44 @@ resource "aws_customer_gateway" "cgw_use1_mdc2" {
   tags = {
     Name        = "MDC2 Customer Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_vpn_connection" "vpn_connection_use1_mdc1" {
-  provider            = "aws.us-east-1"
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_use1.id}"
-  customer_gateway_id = "${aws_customer_gateway.cgw_use1_mdc1.id}"
+  provider            = aws.us-east-1
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gw_use1.id
+  customer_gateway_id = aws_customer_gateway.cgw_use1_mdc1.id
   type                = "ipsec.1"
 
   tags = {
     Name        = "USE1-MDC1"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_vpn_connection" "vpn_connection_use1_mdc2" {
-  provider            = "aws.us-east-1"
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_use1.id}"
-  customer_gateway_id = "${aws_customer_gateway.cgw_use1_mdc2.id}"
+  provider            = aws.us-east-1
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gw_use1.id
+  customer_gateway_id = aws_customer_gateway.cgw_use1_mdc2.id
   type                = "ipsec.1"
 
   tags = {
     Name        = "USE1-MDC2"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 data "aws_vpcs" "moz_internal_us_east_1" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
 
   tags = {
     Name = "moz-internal-us-east-1"
@@ -79,13 +79,13 @@ data "aws_vpcs" "moz_internal_us_east_1" {
 }
 
 resource "aws_vpn_gateway_attachment" "vpn_attachment_use1" {
-  provider       = "aws.us-east-1"
+  provider       = aws.us-east-1
   vpc_id         = join(", ", data.aws_vpcs.moz_internal_us_east_1.ids)
-  vpn_gateway_id = "${aws_vpn_gateway.vpn_gw_use1.id}"
+  vpn_gateway_id = aws_vpn_gateway.vpn_gw_use1.id
 }
 
 data "aws_route_tables" "moz_internal_us_east_1_public" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
 
   tags = {
     Name = "moz-internal-us-east-1-public"
@@ -93,7 +93,7 @@ data "aws_route_tables" "moz_internal_us_east_1_public" {
 }
 
 resource "aws_vpn_gateway_route_propagation" "public_use1" {
-  provider       = "aws.us-east-1"
+  provider       = aws.us-east-1
   route_table_id = join(", ", data.aws_route_tables.moz_internal_us_east_1_public.ids)
-  vpn_gateway_id = "${aws_vpn_gateway.vpn_gw_use1.id}"
+  vpn_gateway_id = aws_vpn_gateway.vpn_gw_use1.id
 }

--- a/terraform/vpns/usw2.tf
+++ b/terraform/vpns/usw2.tf
@@ -1,17 +1,17 @@
 resource "aws_vpn_gateway" "vpn_gw_usw2" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name        = "USW1 VPN Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_customer_gateway" "cgw_usw2_mdc1" {
-  provider   = "aws.us-west-2"
+  provider   = aws.us-west-2
   bgp_asn    = 65048
   ip_address = "63.245.208.251"
   type       = "ipsec.1"
@@ -19,14 +19,14 @@ resource "aws_customer_gateway" "cgw_usw2_mdc1" {
   tags = {
     Name        = "MDC1 Customer Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_customer_gateway" "cgw_usw2_mdc2" {
-  provider   = "aws.us-west-2"
+  provider   = aws.us-west-2
   bgp_asn    = 65050
   ip_address = "63.245.210.251"
   type       = "ipsec.1"
@@ -34,44 +34,44 @@ resource "aws_customer_gateway" "cgw_usw2_mdc2" {
   tags = {
     Name        = "MDC2 Customer Gateway"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_vpn_connection" "vpn_connection_usw2_mdc1" {
-  provider            = "aws.us-west-2"
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw2.id}"
-  customer_gateway_id = "${aws_customer_gateway.cgw_usw2_mdc1.id}"
+  provider            = aws.us-west-2
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gw_usw2.id
+  customer_gateway_id = aws_customer_gateway.cgw_usw2_mdc1.id
   type                = "ipsec.1"
 
   tags = {
     Name        = "USW2-MDC1"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 resource "aws_vpn_connection" "vpn_connection_usw2_mdc2" {
-  provider            = "aws.us-west-2"
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw2.id}"
-  customer_gateway_id = "${aws_customer_gateway.cgw_usw2_mdc2.id}"
+  provider            = aws.us-west-2
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gw_usw2.id
+  customer_gateway_id = aws_customer_gateway.cgw_usw2_mdc2.id
   type                = "ipsec.1"
 
   tags = {
     Name        = "USW2-MDC2"
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "prod"
     Owner       = "relops@mozilla.com"
   }
 }
 
 data "aws_vpcs" "moz_internal_us_west_2" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name = "moz-internal-us-west-2"
@@ -79,13 +79,13 @@ data "aws_vpcs" "moz_internal_us_west_2" {
 }
 
 resource "aws_vpn_gateway_attachment" "vpn_attachment_usw2" {
-  provider       = "aws.us-west-2"
+  provider       = aws.us-west-2
   vpc_id         = join(", ", data.aws_vpcs.moz_internal_us_west_2.ids)
-  vpn_gateway_id = "${aws_vpn_gateway.vpn_gw_usw2.id}"
+  vpn_gateway_id = aws_vpn_gateway.vpn_gw_usw2.id
 }
 
 data "aws_route_tables" "moz_internal_us_west_2_public" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name = "moz-internal-us-west-2-public"
@@ -93,7 +93,7 @@ data "aws_route_tables" "moz_internal_us_west_2_public" {
 }
 
 resource "aws_vpn_gateway_route_propagation" "public_usw2" {
-  provider       = "aws.us-west-2"
+  provider       = aws.us-west-2
   route_table_id = join(", ", data.aws_route_tables.moz_internal_us_west_2_public.ids)
-  vpn_gateway_id = "${aws_vpn_gateway.vpn_gw_usw2.id}"
+  vpn_gateway_id = aws_vpn_gateway.vpn_gw_usw2.id
 }

--- a/terraform/vpns/versions.tf
+++ b/terraform/vpns/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/vpns/versions.tf
+++ b/terraform/vpns/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/vsphere_provider.tf
+++ b/terraform/vsphere_provider.tf
@@ -24,63 +24,63 @@ data "vsphere_datacenter" "mdc1" {
 data "vsphere_datastore_cluster" "mdc1_releng_datastore_cluster" {
   provider      = vsphere.mdc1
   name          = "esx_ssd_releng"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # MDC1 Relops-Terraform resource pool
 data "vsphere_resource_pool" "mdc1_relops_terraform_resource_pool" {
   provider      = vsphere.mdc1
   name          = "Relops-Terraform"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # private.releng.mdc1 vlan275
 data "vsphere_network" "mdc1_releng_network_vlan_275" {
   provider      = vsphere.mdc1
   name          = "RelEng Private VLAN275"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # public.releng.mdc1 vlan3001
 data "vsphere_network" "mdc1_releng_network_vlan_3001" {
   provider      = vsphere.mdc1
   name          = "RelEng Public VLAN3001"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # relabs.releng.mdc1 vlan278
 data "vsphere_network" "mdc1_releng_network_vlan_278" {
   provider      = vsphere.mdc1
   name          = "RelEng RELabs VLAN278"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # srv.releng.mdc1 vlan248
 data "vsphere_network" "mdc1_releng_network_vlan_248" {
   provider      = vsphere.mdc1
   name          = "RelEng Srv VLAN248"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # test.releng.mcd1 vlan256
 data "vsphere_network" "mdc1_releng_network_vlan_256" {
   provider      = vsphere.mdc1
   name          = "RelEng Test VLAN256"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # tier3.releng.mdc1 vlan260
 data "vsphere_network" "mdc1_releng_network_vlan_260" {
   provider      = vsphere.mdc1
   name          = "RelEng Tier3 VLAN260"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 # wintest.releng.mdc1 vlan240
 data "vsphere_network" "mdc1_releng_network_vlan_240" {
   provider      = vsphere.mdc1
   name          = "RelEng WinTest VLAN240"
-  datacenter_id = "${data.vsphere_datacenter.mdc1.id}"
+  datacenter_id = data.vsphere_datacenter.mdc1.id
 }
 
 output "vsphere_mdc1" {
@@ -133,62 +133,62 @@ data "vsphere_datacenter" "mdc2" {
 data "vsphere_datastore_cluster" "mdc2_releng_datastore_cluster" {
   provider      = vsphere.mdc2
   name          = "esx_ssd_releng"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 data "vsphere_resource_pool" "mdc2_relops_terraform_resource_pool" {
   provider      = vsphere.mdc2
   name          = "Relops-Terraform"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # private.releng.mdc2 vlan275
 data "vsphere_network" "mdc2_releng_network_vlan_275" {
   provider      = vsphere.mdc2
   name          = "RelEng-Private VLAN275"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # pu8blic.releng.mdc2 vlan3001
 data "vsphere_network" "mdc2_releng_network_vlan_3001" {
   provider      = vsphere.mdc2
   name          = "RelEng-Public VLAN3001"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # relabs.releng.mdc2 vlan278
 data "vsphere_network" "mdc2_releng_network_vlan_278" {
   provider      = vsphere.mdc2
   name          = "RelEng-RELabs VLAN278"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # srv.releng.mdc2 vlan248
 data "vsphere_network" "mdc2_releng_network_vlan_248" {
   provider      = vsphere.mdc2
   name          = "RelEng-SRV VLAN248"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # test.releng.mdc2 vlan256
 data "vsphere_network" "mdc2_releng_network_vlan_256" {
   provider      = vsphere.mdc2
   name          = "RelEng-Test VLAN256"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # tier3.releng.mdc2 vlan260
 data "vsphere_network" "mdc2_releng_network_vlan_260" {
   provider      = vsphere.mdc2
   name          = "RelEng-Tier3 VLAN260"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 # wintest.releng.mdc2 vlan240
 data "vsphere_network" "mdc2_releng_network_vlan_240" {
   provider      = vsphere.mdc2
   name          = "RelEng-Wintest VLAN240"
-  datacenter_id = "${data.vsphere_datacenter.mdc2.id}"
+  datacenter_id = data.vsphere_datacenter.mdc2.id
 }
 
 output "vsphere_mdc2" {


### PR DESCRIPTION
This PR is an effort bring the entire code base up to date with the new Terraform version v0.13.x.  Most of the work is simply converting the deprecated interpolation-only strings and adding version requirements.  This is a two step process: first, apply v0.12.x compliance and second, apply v0.13.x as recommended by the upgrade docs.