### PR TITLE
[vault_config] add approle for gecko_t_osx_1015_r8_qa

### DIFF
--- a/terraform/vault_config/puppet_approle_ids.tf
+++ b/terraform/vault_config/puppet_approle_ids.tf
@@ -6,6 +6,7 @@ variable "puppet_roles" {
     "mac_v3_signing_dep",
     "gecko_t_osx_1014",
     "gecko_t_osx_1014_staging",
+    "gecko_t_osx_1015_r8_qa",
   ]
 }
 


### PR DESCRIPTION
This PR simply adds a new vault approle mapped to the puppet role `gecko_t_osx_1015_r8_qa`