### PR TITLE
Enable vault audit to cloudwatch

### DIFF
--- a/terraform/vault_config/audit.tf
+++ b/terraform/vault_config/audit.tf
@@ -1,0 +1,12 @@
+resource "vault_audit" "stdout" {
+  type = "file"
+  path = "file"
+
+  # We write logs to stdout since vault executes in docker container.
+  # The logs are then piped to cloud watch.
+  description = "Write logs to stdout which are then routed to cloudwatch"
+  options = {
+    file_path     = "stdout"
+    hmac_accessor = false
+  }
+}

--- a/terraform/vault_config/puppet_approle_ids.tf
+++ b/terraform/vault_config/puppet_approle_ids.tf
@@ -6,6 +6,7 @@ variable "puppet_roles" {
     "mac_v3_signing_dep",
     "gecko_t_osx_1014",
     "gecko_t_osx_1014_staging",
+    "gecko_t_osx_1015_r8_qa",
   ]
 }
 


### PR DESCRIPTION
This PR enables audit logs in vault which are then routed from dockers to cloudwatch