### PR TITLE
[vault] Vault log to cloudwatch

### DIFF
--- a/terraform/vault/cloudwatch.tf
+++ b/terraform/vault/cloudwatch.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "vault" {
+  name = "vault"
+
+  retention_in_days = 90
+
+  tags = merge(local.common_tags,
+    map(
+      "Name", "vault"
+    )
+  )
+}

--- a/terraform/vault/ecs-task-def.tf
+++ b/terraform/vault/ecs-task-def.tf
@@ -5,10 +5,9 @@ resource "aws_ecs_task_definition" "vault" {
   network_mode             = "awsvpc"
   task_role_arn            = aws_iam_role.ecs-task-role.arn
 
-  tags = {
-    Terraform   = "true"
-    Repo_url    = var.repo_url
-    Environment = "Prod"
-    Owner       = "relops@mozilla.com"
-  }
+  tags = merge(local.common_tags,
+    map(
+      "Name", "vault"
+    )
+  )
 }

--- a/terraform/vault/task-definitions/vault.json
+++ b/terraform/vault/task-definitions/vault.json
@@ -25,6 +25,14 @@
       {
         "containerPort": 8201
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "vault",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "container"
+      }
+    }
   }
 ]


### PR DESCRIPTION
This PR creates a cloudwatch log group and turns on the awslogs driver in the vault docker containers.