### PR TITLE
Upgrade to 0.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - run: sudo apt-get install shellcheck
-      - run: curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip"
+      - run: curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.15.4/terraform_0.15.4_linux_amd64.zip"
       - run: unzip /tmp/terraform.zip -d "$HOME/bin"
       - run: terraform --version
       - run: shellcheck --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         VAULT_ADDR="https://127.0.0.1:8200"
         VSPHERE_PASSWORD=empty
 install:
-  - curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip"
+  - curl -sSfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/0.15.4/terraform_0.15.4_linux_amd64.zip"
   - unzip /tmp/terraform.zip -d "$HOME/bin"
   - terraform --version
   - shellcheck --version

--- a/terraform/azure_ad/versions.tf
+++ b/terraform/azure_ad/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/azure_fxci/resource_groups.tf
+++ b/terraform/azure_fxci/resource_groups.tf
@@ -3,8 +3,8 @@ resource "azurerm_resource_group" "relops_terraform" {
   location = "West US"
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "relops_terraform"
-    )
+    tomap({
+      "Name" = "relops_terraform"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-central-us-gecko-t.tf
+++ b/terraform/azure_fxci/rg-central-us-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-central-us-gecko-t" {
   name     = "rg-central-us-gecko-t"
   location = "Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-central-us-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "sacentralusgeckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "sacentralusgeckot"
-    )
+    tomap({
+      "Name" = "sacentralusgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-central-us-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-central-us-gecko-t" {
   location            = "Central US"
   resource_group_name = azurerm_resource_group.rg-central-us-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-central-us-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-central-us-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-central-us-gecko-t" {
     security_group = azurerm_network_security_group.nsg-central-us-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-central-us-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-east-us-2-gecko-t.tf
+++ b/terraform/azure_fxci/rg-east-us-2-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-east-us-2-gecko-t" {
   name     = "rg-east-us-2-gecko-t"
   location = "East US 2"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-east-us-2-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-east-us-2-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "saeastus2geckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "saeastus2geckot"
-    )
+    tomap({
+      "Name" = "saeastus2geckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-east-us-2-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-east-us-2-gecko-t" {
   location            = "East US 2"
   resource_group_name = azurerm_resource_group.rg-east-us-2-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-east-us-2-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-east-us-2-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-east-us-2-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-east-us-2-gecko-t" {
     security_group = azurerm_network_security_group.nsg-east-us-2-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-east-us-2-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-east-us-2-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-east-us-gecko-t.tf
+++ b/terraform/azure_fxci/rg-east-us-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-east-us-gecko-t" {
   name     = "rg-east-us-gecko-t"
   location = "East US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-east-us-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-east-us-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "saeastusgeckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "saeastusgeckot"
-    )
+    tomap({
+      "Name" = "saeastusgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-east-us-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-east-us-gecko-t" {
   location            = "East US"
   resource_group_name = azurerm_resource_group.rg-east-us-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-east-us-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-east-us-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-east-us-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-east-us-gecko-t" {
     security_group = azurerm_network_security_group.nsg-east-us-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-east-us-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-east-us-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-north-central-us-gecko-t.tf
+++ b/terraform/azure_fxci/rg-north-central-us-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-north-central-us-gecko-t" {
   name     = "rg-north-central-us-gecko-t"
   location = "North Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-north-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-north-central-us-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "sanorthcentralusgeckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "sanorthcentralusgeckot"
-    )
+    tomap({
+      "Name" = "sanorthcentralusgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-north-central-us-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-north-central-us-gecko-t" {
   location            = "North Central US"
   resource_group_name = azurerm_resource_group.rg-north-central-us-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-north-centra-us-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-north-centra-us-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-north-central-us-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-north-central-us-gecko-t" {
     security_group = azurerm_network_security_group.nsg-north-central-us-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-north-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-north-central-us-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-packer-through-cib.tf
+++ b/terraform/azure_fxci/rg-packer-through-cib.tf
@@ -2,8 +2,8 @@ resource "azurerm_resource_group" "rg-packer-through-cib" {
   name     = "rg-packer-through-cib"
   location = "Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-packer-through-cib"
-    )
+    tomap({
+      "Name" = "rg-packer-through-cib"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-south-central-us-gecko-t.tf
+++ b/terraform/azure_fxci/rg-south-central-us-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-south-central-us-gecko-t" {
   name     = "rg-south-central-us-gecko-t"
   location = "South Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-south-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-south-central-us-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "sasouthcentralusgeckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "sasouthcentralusgeckot"
-    )
+    tomap({
+      "Name" = "sasouthcentralusgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-south-central-us-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-south-central-us-gecko-t" {
   location            = "South Central US"
   resource_group_name = azurerm_resource_group.rg-south-central-us-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-south-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-south-central-us-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-south-central-us-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-south-central-us-gecko-t" {
     security_group = azurerm_network_security_group.nsg-south-central-us-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-south-central-us-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-south-central-us-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-taskcluster-worker-manager-production.tf
+++ b/terraform/azure_fxci/rg-taskcluster-worker-manager-production.tf
@@ -2,8 +2,8 @@ resource "azurerm_resource_group" "rg-taskcluster-worker-manager-production" {
   name     = "rg-taskcluster-worker-manager-production"
   location = "Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-taskcluster-worker-manager-production"
-    )
+    tomap({
+      "Name" = "rg-taskcluster-worker-manager-production"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-taskcluster-worker-manager-staging.tf
+++ b/terraform/azure_fxci/rg-taskcluster-worker-manager-staging.tf
@@ -2,8 +2,8 @@ resource "azurerm_resource_group" "rg-taskcluster-worker-manager-staging" {
   name     = "rg-taskcluster-worker-manager-staging"
   location = "Central US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-taskcluster-worker-manager-staging"
-    )
+    tomap({
+      "Name" = "rg-taskcluster-worker-manager-staging"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-west-us-2-gecko-t.tf
+++ b/terraform/azure_fxci/rg-west-us-2-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-west-us-2-gecko-t" {
   name     = "rg-west-us-2-gecko-t"
   location = "West US 2"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-west-us-2-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-west-us-2-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "sawestus2geckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "sawest2usgeckot"
-    )
+    tomap({
+      "Name" = "sawest2usgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-west-us2-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-west-us2-gecko-t" {
   location            = "West US 2"
   resource_group_name = azurerm_resource_group.rg-west-us-2-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-west-us2-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-west-us2-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-west-us2-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-west-us2-gecko-t" {
     security_group = azurerm_network_security_group.nsg-west-us2-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-west-us-2-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-west-us-2-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/rg-west-us-gecko-t.tf
+++ b/terraform/azure_fxci/rg-west-us-gecko-t.tf
@@ -2,9 +2,9 @@ resource "azurerm_resource_group" "rg-west-us-gecko-t" {
   name     = "rg-west-us-gecko-t"
   location = "West US"
   tags = merge(local.common_tags,
-    map(
-      "Name", "rg-west-us-gecko-t"
-    )
+    tomap({
+      "Name" = "rg-west-us-gecko-t"
+    })
   )
 }
 # storage account names can only consist of lowercase letters and numbers
@@ -15,9 +15,9 @@ resource "azurerm_storage_account" "sawestusgeckot" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   tags = merge(local.common_tags,
-    map(
-      "Name", "sawestusgeckot"
-    )
+    tomap({
+      "Name" = "sawestusgeckot"
+    })
   )
 }
 resource "azurerm_network_security_group" "nsg-west-us-gecko-t" {
@@ -25,9 +25,9 @@ resource "azurerm_network_security_group" "nsg-west-us-gecko-t" {
   location            = "West US"
   resource_group_name = azurerm_resource_group.rg-west-us-gecko-t.name
   tags = merge(local.common_tags,
-    map(
-      "Name", "nsg-west-us-gecko-t"
-    )
+    tomap({
+      "Name" = "nsg-west-us-gecko-t"
+    })
   )
 }
 resource "azurerm_virtual_network" "vn-west-us-gecko-t" {
@@ -42,8 +42,8 @@ resource "azurerm_virtual_network" "vn-west-us-gecko-t" {
     security_group = azurerm_network_security_group.nsg-west-us-gecko-t.id
   }
   tags = merge(local.common_tags,
-    map(
-      "Name", "vn-west-us-gecko-t"
-    )
+    tomap({
+      "Name" = "vn-west-us-gecko-t"
+    })
   )
 }

--- a/terraform/azure_fxci/versions.tf
+++ b/terraform/azure_fxci/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/base/versions.tf
+++ b/terraform/base/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/bitbar-devicepool/versions.tf
+++ b/terraform/bitbar-devicepool/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/puppetagain_ca_codecommit/versions.tf
+++ b/terraform/puppetagain_ca_codecommit/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/ronin-puppet-package-repo/versions.tf
+++ b/terraform/ronin-puppet-package-repo/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/sops_codecommit/versions.tf
+++ b/terraform/sops_codecommit/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/taskqueue-influxdb-metrics/versions.tf
+++ b/terraform/taskqueue-influxdb-metrics/versions.tf
@@ -1,6 +1,5 @@
-
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -2,9 +2,9 @@ resource "aws_ecs_cluster" "main" {
   name = "telegraf"
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "telegraf"
-    )
+    tomap({
+      "Name" = "telegraf"
+    })
   )
 }
 

--- a/terraform/telegraf/versions.tf
+++ b/terraform/telegraf/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }

--- a/terraform/vault/cloudwatch.tf
+++ b/terraform/vault/cloudwatch.tf
@@ -4,8 +4,8 @@ resource "aws_cloudwatch_log_group" "vault" {
   retention_in_days = 90
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "vault"
-    )
+    tomap({
+      "Name" = "vault"
+    })
   )
 }

--- a/terraform/vault/dynamodb.tf
+++ b/terraform/vault/dynamodb.tf
@@ -15,9 +15,9 @@ resource "aws_dynamodb_table" "dynamodb-table" {
   }
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "vault-dynamodb-table"
-    )
+    tomap({
+      "Name" = "vault-dynamodb-table"
+    })
   )
 }
 

--- a/terraform/vault/ecs-cluster.tf
+++ b/terraform/vault/ecs-cluster.tf
@@ -2,9 +2,9 @@ resource "aws_ecs_cluster" "vault" {
   name = "vault"
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "vault"
-    )
+    tomap({
+      "Name" = "vault"
+    })
   )
 }
 

--- a/terraform/vault/ecs-task-def.tf
+++ b/terraform/vault/ecs-task-def.tf
@@ -6,8 +6,8 @@ resource "aws_ecs_task_definition" "vault" {
   task_role_arn            = aws_iam_role.ecs-task-role.arn
 
   tags = merge(local.common_tags,
-    map(
-      "Name", "vault"
-    )
+    tomap({
+      "Name" = "vault"
+    })
   )
 }

--- a/terraform/vault/versions.tf
+++ b/terraform/vault/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/vault_config/versions.tf
+++ b/terraform/vault_config/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/vpns/versions.tf
+++ b/terraform/vpns/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
This PR updates all of the projects to be compliant with, and require, Terraform >= v0.15.x.