### PR TITLE
[vault] refactor autoscaling group to launch template

### DIFF
--- a/terraform/vault/.terraform.lock.hcl
+++ b/terraform/vault/.terraform.lock.hcl
@@ -2,18 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.21.0"
+  version = "3.46.0"
   hashes = [
-    "h1:YGpoWikUMRAqKJAzT5llGi4fE/ce/MFqfXg7m0f7VNA=",
-    "zh:11b8c85d063775029245e86ebce346ed86aa77aefaa72dc558da37ea347aa77c",
-    "zh:15f0f5bcbcffe1d2aeaa595f6573f0779932bd3a7647f28ad6aacf1a20f35562",
-    "zh:4459e3de50fa9ff64ce50b812ddbcfe7f6fe5fcdd1c23c35a85f11bda5ee8cdb",
-    "zh:4a146a958ff5997dca61c016330ed0546093873cce2791cdb727ef897b3d5bdd",
-    "zh:698717e66ad6cd58842b696c46c1f4d97c0e3cdad1b872665d79f74e6bbc4310",
-    "zh:7e270b37e275d17195993c0b13221e400a67eb26850517977a0587de092a055f",
-    "zh:7f14438403ca2ebbe39561f13b78d44bad83d519e907414c2e1f1dc9c2059c0f",
-    "zh:9799606edd2079c92e181e8a0f022ac69f2e7093bb23cc9348dc9db9b76aa7da",
-    "zh:b947e1a3768650aab0d4679a5202d17464f4ad8c429a57627f9cadf5b78843fc",
-    "zh:f7fbd8827afcbab1c5da907283acde543cd0ad8513cec0eea14afb7b926b5a5a",
+    "h1:aChsFp4Zfrt0z+6IEbQYHWqrQYbDPpBd59bX2I6QK1w=",
+    "zh:3ec89dba1d9ed494c5a8069b98d230289c736f5d7abb0d47d6d657d1c9a22a38",
+    "zh:47dd0ba54897a43aa22a9009d9eddec30d2e656a6153219335af23c5be609e47",
+    "zh:482164d6d7782d574d6ef3740d02a3b3566c9e3f03021b497675aa4aa6855ef9",
+    "zh:5b068dd406e0989cb1b1ce390b8dc33eb77997a594b500dea3d39595e67086b3",
+    "zh:7bb6dbe99cd483db05d28e0e3109dac6be233961f816b1145035f0f49b30bbde",
+    "zh:7c245831b5e062b0207b988821d6ed674516c78b81afe0fc015a58e40b973d05",
+    "zh:7f3fb2457ff59c6e3795acd0995cb3ec3b0f22fce5ab8b261e8480bc752787a6",
+    "zh:8dcbb64802f38dc20fccedaf93dbfbf367859eba81fe7fa4dc734323f287cf4a",
+    "zh:da6c412927a514e46ff81e4044ce29617b7c11d33db99ff959a761f97ca09fce",
+    "zh:e670cda0e9ffcd791d94bb1822c26e2a1d26cb0e7a7b655019f4375a14e04e90",
+    "zh:ebf9c5ef3eceebc1c21bcd31e535e5c323c3bf6ca5918959e297e9a6617d8094",
   ]
 }

--- a/terraform/vault/ecs-task-def.tf
+++ b/terraform/vault/ecs-task-def.tf
@@ -1,6 +1,6 @@
 resource "aws_ecs_task_definition" "vault" {
   family                   = "vault"
-  container_definitions    = file("task-definitions/vault.json")
+  container_definitions    = templatefile("task-definitions/vault.json", { docker_version = var.docker_version })
   requires_compatibilities = ["EC2"]
   network_mode             = "awsvpc"
   task_role_arn            = aws_iam_role.ecs-task-role.arn

--- a/terraform/vault/task-definitions/vault.json
+++ b/terraform/vault/task-definitions/vault.json
@@ -2,7 +2,7 @@
   {
     "name": "vault",
     "containerName": "vault",
-    "image": "vault:1.7.2",
+    "image": "vault:${docker_version}",
     "memory": 6144,
     "linuxParameters": {
       "capabilities": {

--- a/terraform/vault/terraform.tfvars
+++ b/terraform/vault/terraform.tfvars
@@ -4,8 +4,6 @@ tag_production_state = "production"
 
 tag_owner_email = "jwatkins@mozilla.com"
 
-ecs_ami = "ami-0b89310f457a9e90e"
-
 instance_type = "m5.large"
 
 max_instance_size = "4"
@@ -13,3 +11,7 @@ max_instance_size = "4"
 min_instance_size = "2"
 
 desired_capacity = "2"
+
+ecs_ami = "ami-0b89310f457a9e90e"
+
+docker_version = "1.7.3"

--- a/terraform/vault/vars.tf
+++ b/terraform/vault/vars.tf
@@ -17,3 +17,7 @@ variable "min_instance_size" {
 variable "desired_capacity" {
   description = "Desired number of instances in the cluster"
 }
+
+variable "docker_version" {
+  description = "Version of the terraform docker image"
+}


### PR DESCRIPTION
This PR is a refactor of vault to use the launch template instead of a launch configuration.  This allow the use of automatic scaling group instance refresh then the template changes which removes the need to manually call a refresh after updating the ami id.

This also:

- updates the aws provider to latest
- fixes some resource tagging
- moves the docker version to a terraform variable