### PR TITLE
fix copy and paste error

### DIFF
--- a/terraform/azure_ad/sp_taskcluster_worker_managers.tf
+++ b/terraform/azure_ad/sp_taskcluster_worker_managers.tf
@@ -119,6 +119,6 @@ resource "azurerm_role_assignment" "taskcluster-worker-manager-production_subscr
 # role assignment: taskcluster-worker-manager-staging, contributor (built in role), within subscription scope
 resource "azurerm_role_assignment" "taskcluster-worker-manager-staging_subscription_contributor" {
   role_definition_name = "Contributor"
-  principal_id         = azuread_service_principal.taskcluster-worker-manager-production.object_id
+  principal_id         = azuread_service_principal.taskcluster-worker-manager-staging.object_id
   scope                = data.azurerm_subscription.currentSubscription.id
 }


### PR DESCRIPTION
Fix copy and paste error to give taskcluster-worker-manager-staging contributor access. 

However, had to manually add it through the UI. Trying to apply the Terraform code leads to: 

```
│ Error: Error: Resource Group "Puppet-Test-Kitchen" was not found
│
│   with data.azurerm_resource_group.puppet_test_kitchen_rg,
│   on sp_puppet_test_kitchen.tf line 5, in data "azurerm_resource_group" "puppet_test_kitchen_rg":
│    5: data "azurerm_resource_group" "puppet_test_kitchen_rg" {
```

I am not sure what has changed there. 
