### PR TITLE
add GCP linux ronin puppet assets bucket

### DIFF
--- a/terraform/base/.terraform.lock.hcl
+++ b/terraform/base/.terraform.lock.hcl
@@ -2,20 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.21.0"
+  version     = "4.30.0"
   constraints = ">= 2.68.0"
   hashes = [
-    "h1:YGpoWikUMRAqKJAzT5llGi4fE/ce/MFqfXg7m0f7VNA=",
-    "h1:jvcUKDDNFXjIRWoxfw55vvfFTlSgnLMYe1qiSZNtWoE=",
-    "zh:11b8c85d063775029245e86ebce346ed86aa77aefaa72dc558da37ea347aa77c",
-    "zh:15f0f5bcbcffe1d2aeaa595f6573f0779932bd3a7647f28ad6aacf1a20f35562",
-    "zh:4459e3de50fa9ff64ce50b812ddbcfe7f6fe5fcdd1c23c35a85f11bda5ee8cdb",
-    "zh:4a146a958ff5997dca61c016330ed0546093873cce2791cdb727ef897b3d5bdd",
-    "zh:698717e66ad6cd58842b696c46c1f4d97c0e3cdad1b872665d79f74e6bbc4310",
-    "zh:7e270b37e275d17195993c0b13221e400a67eb26850517977a0587de092a055f",
-    "zh:7f14438403ca2ebbe39561f13b78d44bad83d519e907414c2e1f1dc9c2059c0f",
-    "zh:9799606edd2079c92e181e8a0f022ac69f2e7093bb23cc9348dc9db9b76aa7da",
-    "zh:b947e1a3768650aab0d4679a5202d17464f4ad8c429a57627f9cadf5b78843fc",
-    "zh:f7fbd8827afcbab1c5da907283acde543cd0ad8513cec0eea14afb7b926b5a5a",
+    "h1:/TOHrFrfQaj16peTH3D7JmEgqAVyO6EpHNxaq1qxIoE=",
+    "zh:08213f3ba960621448754211f148730edb59194919ee476b0231b769a5355028",
+    "zh:29c90d6f8bdae0e1469417ade28fa79c74c2af49593c1e2f24f07bacbca9e2c9",
+    "zh:5c6e9fab64ad68de6cd4ec6cbb20b0f75ba1e51a8efaeda3fe65419f096a06cb",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bf42718580e8c5097227df34e1bfa0a10a23eac9f527d97c2819c163087b402",
+    "zh:9f87e42e0f3d145fb0ad4aaff7ddded5720a64f9303956b33bd274c6dd05c05b",
+    "zh:bf0519ed9615bc408b72a0aebe1cc075d4c2042325590ba13dd264cd264907ea",
+    "zh:c3ac9e1cbd0935614f5a3c9cdb4cf9c6a1045937fe38e61da7c5c0fb7a069870",
+    "zh:d0c184476ada38c50acc068214ed1252b4fcf80b6be900fc1aed32cbb49f8ff6",
+    "zh:d4987dc7b7a69ea58f2b3ff0ea4ffc1b61a97881dbb8583c9fcf9444b753a6c2",
+    "zh:e8037376c81aeb98d8286dc19fba7f8eb053444d4b9484ea6a922382cffc1a85",
+    "zh:ecdabb44b48addc8483bca7bd683614a347367ae950ca8b6a6880679f5c12abd",
   ]
 }

--- a/terraform/base/tf_state_lock_ronin-puppet-assets.tf
+++ b/terraform/base/tf_state_lock_ronin-puppet-assets.tf
@@ -1,0 +1,19 @@
+resource "aws_dynamodb_table" "tf_state_lock_ronin-puppet-assets" {
+  name           = "tf_state_lock_ronin-puppet-assets"
+  hash_key       = "LockID"
+  read_capacity  = 20
+  write_capacity = 20
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "ronin-puppet-assets Terraform State Lock Table"
+    Terraform   = "true"
+    Repo_url    = var.repo_url
+    Environment = "prod"
+    Owner       = "relops@mozilla.com"
+  }
+}

--- a/terraform/ronin-puppet-assets/.terraform.lock.hcl
+++ b/terraform/ronin-puppet-assets/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.30.0"
+  hashes = [
+    "h1:/TOHrFrfQaj16peTH3D7JmEgqAVyO6EpHNxaq1qxIoE=",
+    "zh:08213f3ba960621448754211f148730edb59194919ee476b0231b769a5355028",
+    "zh:29c90d6f8bdae0e1469417ade28fa79c74c2af49593c1e2f24f07bacbca9e2c9",
+    "zh:5c6e9fab64ad68de6cd4ec6cbb20b0f75ba1e51a8efaeda3fe65419f096a06cb",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bf42718580e8c5097227df34e1bfa0a10a23eac9f527d97c2819c163087b402",
+    "zh:9f87e42e0f3d145fb0ad4aaff7ddded5720a64f9303956b33bd274c6dd05c05b",
+    "zh:bf0519ed9615bc408b72a0aebe1cc075d4c2042325590ba13dd264cd264907ea",
+    "zh:c3ac9e1cbd0935614f5a3c9cdb4cf9c6a1045937fe38e61da7c5c0fb7a069870",
+    "zh:d0c184476ada38c50acc068214ed1252b4fcf80b6be900fc1aed32cbb49f8ff6",
+    "zh:d4987dc7b7a69ea58f2b3ff0ea4ffc1b61a97881dbb8583c9fcf9444b753a6c2",
+    "zh:e8037376c81aeb98d8286dc19fba7f8eb053444d4b9484ea6a922382cffc1a85",
+    "zh:ecdabb44b48addc8483bca7bd683614a347367ae950ca8b6a6880679f5c12abd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.36.0"
+  hashes = [
+    "h1:uxt4Wd6Qj+x1YYtNp7P7ZSsIKlhpZe2Er0cyjVIaeuc=",
+    "zh:020a56ccea48826a66578d7e9e044655be462ec1910dee2b24442b00f2127e30",
+    "zh:47bc0e02551a6738ed4a6cdff77b7955d02a8e7a044e47bbf6652e4d12ff2d90",
+    "zh:a63af4f236def6f05294d10752d7d4633f1f8d5064f82e2215c298ec199d0621",
+    "zh:bc44662188605400a56277113326c0863103009fe05403d056c72c27aab72747",
+    "zh:c2507a6eedee76dcba8327b54280bca7a321700d81f0cb09d83abdaf7cc74a17",
+    "zh:c37b97950410d256e4e4d89be759bcd80476544a5f4c4b2ca6953eb89a698420",
+    "zh:ce432c9d0a47bb6614b7fa6a335f35887c0e5ab833e812a8dd37e699e8bc8ea6",
+    "zh:d847880e86aa14e8cf52e36615b3bb6a6fd578729a5cb33035292826181dd62b",
+    "zh:e5e9980578a93f392e710f22795e9183332f8efe8cd33f3bf71e6b6dd51ac6b0",
+    "zh:eb9eabb5851ee005eea862669290d910e2d180f31c301855c788b701cecbcd2f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9c75793eaeb2a34a12789359bff3d3c40d97c4f2f724d545aa997815dd5679f",
+  ]
+}

--- a/terraform/ronin-puppet-assets/backend.tf
+++ b/terraform/ronin-puppet-assets/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "relops-tf-states"
+    key            = "ronin-puppet-assets.tfstate"
+    dynamodb_table = "tf_state_lock_ronin-puppet-assets"
+    region         = "us-west-2"
+  }
+}

--- a/terraform/ronin-puppet-assets/gcloud_provider.tf
+++ b/terraform/ronin-puppet-assets/gcloud_provider.tf
@@ -1,0 +1,6 @@
+provider "google" {
+  project = "ronin-puppet-assets"
+  region  = "us-west1"
+  zone    = "us-west1-b"
+}
+

--- a/terraform/ronin-puppet-assets/gcloud_storage.tf
+++ b/terraform/ronin-puppet-assets/gcloud_storage.tf
@@ -1,0 +1,15 @@
+# linux (and android)
+
+resource "google_storage_default_object_access_control" "linux_public_rule" {
+  bucket = google_storage_bucket.linux_bucket.name
+  role   = "READER"
+  entity = "allUsers"
+}
+
+resource "google_storage_bucket" "linux_bucket" {
+  name          = "ronin-puppet-linux-assets"
+  location      = "US-WEST1"
+  storage_class = "STANDARD" # default value
+}
+
+# mac: TBD

--- a/terraform/ronin-puppet-assets/providers.tf
+++ b/terraform/ronin-puppet-assets/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/terraform/ronin-puppet-assets/resources.tf
+++ b/terraform/ronin-puppet-assets/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/terraform/ronin-puppet-assets/variables.tf
+++ b/terraform/ronin-puppet-assets/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
Already `tf apply`'d.

See https://mozilla-hub.atlassian.net/browse/RELOPS-217.