### PR TITLE
add support for ronin-puppet windows assets

### DIFF
--- a/terraform/azure_fxci/ronin-puppet-windows-assets.tf
+++ b/terraform/azure_fxci/ronin-puppet-windows-assets.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "this" {
+  name     = "ronin-puppet-windows-assets"
+  location = "westus2"
+}
+
+resource "azurerm_storage_account" "this" {
+  name                     = "roninpuppetassets"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "binaries"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "blob"
+}

--- a/terraform/ronin-puppet-assets/.terraform.lock.hcl
+++ b/terraform/ronin-puppet-assets/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "4.30.0"
   hashes = [
     "h1:/TOHrFrfQaj16peTH3D7JmEgqAVyO6EpHNxaq1qxIoE=",
+    "h1:BFfhRf8my/aa0+YOSJv0xfjLQkToF475TJTMhTZfYec=",
     "zh:08213f3ba960621448754211f148730edb59194919ee476b0231b769a5355028",
     "zh:29c90d6f8bdae0e1469417ade28fa79c74c2af49593c1e2f24f07bacbca9e2c9",
     "zh:5c6e9fab64ad68de6cd4ec6cbb20b0f75ba1e51a8efaeda3fe65419f096a06cb",
@@ -20,9 +21,29 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.28.0"
+  hashes = [
+    "h1:eQRgBnX2TQ6H4q3sg4WUV1OhN21UdhQYrcyAnyu3U/U=",
+    "zh:1c01bc8cba03c642d108df034744253ac7e625d7528d77ae57b65809cd08e519",
+    "zh:52e8a26edde4e9254063b0961079497defc4d3255c2adcc00caca8b960347571",
+    "zh:694e4f0e6c79265ebfe62656dfd7b30e245e3adba513f70711a050f46819f1a5",
+    "zh:6ff9fddb694afa04851dcd38e1865bf7afe02690a33b717137a27dc48c049dd1",
+    "zh:77152823230857b1b0f3b66ff0e38ccc1cca245d531813e8ad4ec0e7dee64b6e",
+    "zh:7fb273228e63de7846ae64539cf0836eac652a045b915e9cc470c63131cbf88f",
+    "zh:8f3c784f3b953a6de44c23828a8a47a77bfdb63b09af7cca9ae3175b2870151e",
+    "zh:92f5feaf7a109dd30d6982af5c68d914c62b294c872f84fa0e1ab24ffea55d1c",
+    "zh:b74a67fc97966184e7d111fd66316313dfa0ff592ebd9fc1ae4672df317cf3bf",
+    "zh:f15e22acf5a9186d8647e1539bb904c5605606094b7ebec7d8eb479735573b37",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f91ddbf9310b0f815477a88bdf9969b06a50752c330250b9a6626d89e620ee23",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version = "4.36.0"
   hashes = [
+    "h1:BdxWobwmDlFFPN6TityxnzPH1Ld4Xd5zcZ4XLXTLn5U=",
     "h1:uxt4Wd6Qj+x1YYtNp7P7ZSsIKlhpZe2Er0cyjVIaeuc=",
     "zh:020a56ccea48826a66578d7e9e044655be462ec1910dee2b24442b00f2127e30",
     "zh:47bc0e02551a6738ed4a6cdff77b7955d02a8e7a044e47bbf6652e4d12ff2d90",


### PR DESCRIPTION
Looks like it may destroy 2 runbooks. @markcor thoughts?

```hcl
Terraform will perform the following actions:

  # azurerm_automation_job_schedule.nv6_audit_delete will be destroyed
  # (because azurerm_automation_job_schedule.nv6_audit_delete is not in configuration)
  - resource "azurerm_automation_job_schedule" "nv6_audit_delete" {
      - automation_account_name = "resource-monitor" -> null
      - id                      = "/subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/rg-central-us-runbooks/providers/Microsoft.Automation/automationAccounts/resource-monitor/jobSchedules/802bb3c1-7b75-46d2-9860-456c8f31c5a3" -> null
      - job_schedule_id         = "802bb3c1-7b75-46d2-9860-456c8f31c5a3" -> null
      - parameters              = {} -> null
      - resource_group_name     = "rg-central-us-runbooks" -> null
      - runbook_name            = "nv6_audit_delete" -> null
      - schedule_name           = "every-4-hours" -> null
    }

  # azurerm_automation_runbook.nv6_audit_delete will be destroyed
  # (because azurerm_automation_runbook.nv6_audit_delete is not in configuration)
  - resource "azurerm_automation_runbook" "nv6_audit_delete" {
      - automation_account_name = "resource-monitor" -> null
      - content                 = <<-EOT
            # Reference: https://mozilla-hub.atlassian.net/browse/RELOPS-231
            # Temp solution to remove old NV6 VMs

            $connection = Get-AutomationConnection -Name AzureRunAsConnection
            $connectionResult = Connect-AzAccount -ServicePrincipal -Tenant $connection.TenantID -ApplicationId $connection.ApplicationID -CertificateThumbprint $connection.CertificateThumbprint

            $current = (get-date -format g)
            $vms = (get-azvm)
            $current = ((Get-Date).ToUniversalTime())

            foreach ($vm in $vms) {
                if ($VM.HardwareProfile.VMSize -eq "Standard_NV6") {
                        $status = (get-azvm -resourcegroup $vm.ResourceGroupName -name $vm.Name -status -ErrorAction:SilentlyContinue)
                        $provisioned_time = $status.Disks[0].Statuses[0].Time
                        $up_time = (New-TimeSpan -Start $provisioned_time -end $current -ErrorAction:SilentlyContinue)
                        $hrs = $up_time.hours
                        $dys = $up_time.days
                        [int]$hrs_up = ($dys * 24) + $hrs
                        if ($hrs_up -ge 12) {
                                Write-Output ('ID: {0} Location: {1} up_time: {2} hrs Name: {3}' -f $vm.VmID, $vm.location, $hrs_up, $vm.Name)
                                Remove-AzVM -Name $vm.Name -ResourceGroupName $vm.ResourceGroupName -Force
                        }
                }
            }
        EOT -> null
      - description             = "Audit and delete oldNV6 VMs" -> null
      - id                      = "/subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/rg-central-us-runbooks/providers/Microsoft.Automation/automationAccounts/resource-monitor/runbooks/nv6_audit_delete" -> null
      - job_schedule            = [
          - {
              - job_schedule_id = "802bb3c1-7b75-46d2-9860-456c8f31c5a3"
              - parameters      = {}
              - run_on          = ""
              - schedule_name   = "every-4-hours"
            },
        ] -> null
      - location                = "centralus" -> null
      - log_progress            = true -> null
      - log_verbose             = false -> null
      - name                    = "nv6_audit_delete" -> null
      - resource_group_name     = "rg-central-us-runbooks" -> null
      - runbook_type            = "PowerShell" -> null
      - tags                    = {
          - "Name"             = "nv6_audit_delete"
          - "owner_email"      = "mcornmesser@mozilla.com"
          - "production_state" = "production"
          - "project_name"     = "azure_fxci"
          - "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          - "terraform"        = "true"
        } -> null
    }

  # azurerm_resource_group.this will be created
  + resource "azurerm_resource_group" "this" {
      + id       = (known after apply)
      + location = "westus2"
      + name     = "ronin-puppet-windows-assets"
    }

  # azurerm_storage_account.this will be created
  + resource "azurerm_storage_account" "this" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "LRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "westus2"
      + min_tls_version                   = "TLS1_2"
      + name                              = "roninpuppetassets"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "ronin-puppet-windows-assets"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_storage_container.this will be created
  + resource "azurerm_storage_container" "this" {
      + container_access_type   = "blob"
      + has_immutability_policy = (known after apply)
      + has_legal_hold          = (known after apply)
      + id                      = (known after apply)
      + metadata                = (known after apply)
      + name                    = "binaries"
      + resource_manager_id     = (known after apply)
      + storage_account_name    = "roninpuppetassets"
    }

Plan: 3 to add, 0 to change, 2 to destroy.
```