### PR TITLE
Add resources for joel/testers to test new images

### DIFF
--- a/terraform/azure_fxci/devloaner-resources.tf
+++ b/terraform/azure_fxci/devloaner-resources.tf
@@ -1,5 +1,5 @@
-resource "azurerm_resource_group" "devtest" {
-  for_each = var.devtest
+resource "azurerm_resource_group" "devloaner" {
+  for_each = var.devloaner
   name     = "rg-${each.value.rgname}"
   location = each.value.rglocation
   tags = merge(local.common_tags,
@@ -9,10 +9,10 @@ resource "azurerm_resource_group" "devtest" {
   )
 }
 
-resource "azurerm_storage_account" "devtest" {
-  for_each                 = var.devtest
+resource "azurerm_storage_account" "devloaner" {
+  for_each                 = var.devloaner
   name                     = replace("sa${each.value.rgname}", "/\\W|_|\\s/", "")
-  resource_group_name      = azurerm_resource_group.devtest[each.key].name
+  resource_group_name      = azurerm_resource_group.devloaner[each.key].name
   location                 = each.value.rglocation
   account_replication_type = "GRS"
   account_tier             = "Standard"
@@ -23,10 +23,10 @@ resource "azurerm_storage_account" "devtest" {
   )
 }
 
-resource "azurerm_network_security_group" "devtest" {
-  for_each            = var.devtest
+resource "azurerm_network_security_group" "devloaner" {
+  for_each            = var.devloaner
   name                = "nsg-${each.value.rgname}"
-  resource_group_name = azurerm_resource_group.devtest[each.key].name
+  resource_group_name = azurerm_resource_group.devloaner[each.key].name
   location            = each.value.rglocation
   tags = merge(local.common_tags,
     tomap({
@@ -35,10 +35,10 @@ resource "azurerm_network_security_group" "devtest" {
   )
 }
 
-resource "azurerm_virtual_network" "devtest" {
-  for_each            = var.devtest
+resource "azurerm_virtual_network" "devloaner" {
+  for_each            = var.devloaner
   name                = "vn-${each.value.rgname}"
-  resource_group_name = azurerm_resource_group.devtest[each.key].name
+  resource_group_name = azurerm_resource_group.devloaner[each.key].name
   location            = each.value.rglocation
   address_space       = ["10.0.0.0/24"]
   dns_servers         = ["1.1.1.1", "1.1.1.0"]
@@ -50,6 +50,6 @@ resource "azurerm_virtual_network" "devtest" {
   subnet {
     name           = "sn-${each.value.rgname}"
     address_prefix = "10.0.0.0/24"
-    security_group = azurerm_network_security_group.devtest[each.key].id
+    security_group = azurerm_network_security_group.devloaner[each.key].id
   }
 }

--- a/terraform/azure_fxci/devtest-resources.tf
+++ b/terraform/azure_fxci/devtest-resources.tf
@@ -1,0 +1,55 @@
+resource "azurerm_resource_group" "devtest" {
+  for_each = var.devtest
+  name     = "rg-${each.value.rgname}"
+  location = each.value.rglocation
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "${each.value.rgname}"
+    })
+  )
+}
+
+resource "azurerm_storage_account" "devtest" {
+  for_each                 = var.devtest
+  name                     = replace("sa${each.value.rgname}", "/\\W|_|\\s/", "")
+  resource_group_name      = azurerm_resource_group.devtest[each.key].name
+  location                 = each.value.rglocation
+  account_replication_type = "GRS"
+  account_tier             = "Standard"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "${each.value.rgname}"
+    })
+  )
+}
+
+resource "azurerm_network_security_group" "devtest" {
+  for_each            = var.devtest
+  name                = "nsg-${each.value.rgname}"
+  resource_group_name = azurerm_resource_group.devtest[each.key].name
+  location            = each.value.rglocation
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "${each.value.rgname}"
+    })
+  )
+}
+
+resource "azurerm_virtual_network" "devtest" {
+  for_each            = var.devtest
+  name                = "vn-${each.value.rgname}"
+  resource_group_name = azurerm_resource_group.devtest[each.key].name
+  location            = each.value.rglocation
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "${each.value.rgname}"
+    })
+  )
+  subnet {
+    name           = "sn-${each.value.rgname}"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.devtest[each.key].id
+  }
+}

--- a/terraform/azure_fxci/local-variables.tf
+++ b/terraform/azure_fxci/local-variables.tf
@@ -60,12 +60,12 @@ variable "gecko3" {
   }
 }
 
-variable "devtest" {
+variable "devloaner" {
   description = "developers using windows vms to test"
   type        = map(any)
   default = {
-    "rg-west-us-devtest" = {
-      rgname     = "central-us-devtest"
+    "rg-west-us-devloaner" = {
+      rgname     = "central-us-devloaner"
       rglocation = "centralus"
     }
   }

--- a/terraform/azure_fxci/local-variables.tf
+++ b/terraform/azure_fxci/local-variables.tf
@@ -59,3 +59,14 @@ variable "gecko3" {
     }
   }
 }
+
+variable "devtest" {
+  description = "developers using windows vms to test"
+  type        = map(any)
+  default = {
+    "rg-west-us-devtest" = {
+      rgname     = "central-us-devtest"
+      rglocation = "centralus"
+    }
+  }
+}


### PR DESCRIPTION
Terraform plan:


```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # azurerm_network_security_group.devtest["rg-west-us-devtest"] will be created
  + resource "azurerm_network_security_group" "devtest" {
      + id                  = (known after apply)
      + location            = "centralus"
      + name                = "nsg-central-us-devtest"
      + resource_group_name = "rg-central-us-devtest"
      + security_rule       = (known after apply)
      + tags                = {
          + "Name"             = "central-us-devtest"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_resource_group.devtest["rg-west-us-devtest"] will be created
  + resource "azurerm_resource_group" "devtest" {
      + id       = (known after apply)
      + location = "centralus"
      + name     = "rg-central-us-devtest"
      + tags     = {
          + "Name"             = "central-us-devtest"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_storage_account.devtest["rg-west-us-devtest"] will be created
  + resource "azurerm_storage_account" "devtest" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "GRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "centralus"
      + min_tls_version                   = "TLS1_2"
      + name                              = "sacentralusdevtest"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-central-us-devtest"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "Name"             = "central-us-devtest"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_virtual_network.devtest["rg-west-us-devtest"] will be created
  + resource "azurerm_virtual_network" "devtest" {
      + address_space       = [
          + "10.0.0.0/24",
        ]
      + dns_servers         = [
          + "1.1.1.1",
          + "1.1.1.0",
        ]
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "centralus"
      + name                = "vn-central-us-devtest"
      + resource_group_name = "rg-central-us-devtest"
      + subnet              = [
          + {
              + address_prefix = "10.0.0.0/24"
              + id             = (known after apply)
              + name           = "sn-central-us-devtest"
              + security_group = (known after apply)
            },
        ]
      + tags                = {
          + "Name"             = "central-us-devtest"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```