### PR TITLE
Add Canada Central, South India, & West US 3

### DIFF
--- a/terraform/azure_fxci/gecko-t-resources.tf
+++ b/terraform/azure_fxci/gecko-t-resources.tf
@@ -1,3 +1,106 @@
+resource "azurerm_resource_group" "rg-canada-central-gecko-t" {
+  name     = "rg-canada-central-gecko-t"
+  location = "Canada Central"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "rg-canada-central-gecko-t"
+    })
+  )
+}
+# storage account names can only consist of lowercase letters and numbers
+resource "azurerm_storage_account" "sacanadacentralgeckot" {
+  name                     = "sacanadacentralgeckot"
+  resource_group_name      = azurerm_resource_group.rg-canada-central-gecko-t.name
+  location                 = "Canada Central"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "sacanadacentralgeckot"
+    })
+  )
+}
+
+resource "azurerm_network_security_group" "nsg-canada-central-gecko-t" {
+  name                = "nsg-canada-central-gecko-t"
+  location            = "Canada Central"
+  resource_group_name      = azurerm_resource_group.rg-canada-central-gecko-t.name
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "nsg-canada-central-gecko-t"
+    })
+  )
+}
+resource "azurerm_virtual_network" "vn-canada-central-gecko-t" {
+  name                = "vn-canada-central-gecko-t"
+  location            = "Canada Central"
+  resource_group_name      = azurerm_resource_group.rg-canada-central-gecko-t.name
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  subnet {
+    name           = "sn-canada-central-gecko-t"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.nsg-canada-central-gecko-t.id
+  }
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "vn-canada-central-gecko-t"
+    })
+  )
+}
+
+## Central India
+resource "azurerm_resource_group" "rg-central-india-gecko-t" {
+  name     = "rg-central-india-gecko-t"
+  location = "Central India"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "rg-central-india-gecko-t"
+    })
+  )
+}
+# storage account names can only consist of lowercase letters and numbers
+resource "azurerm_storage_account" "sacentralindiageckot" {
+  name                     = "sacentralindiageckot"
+  resource_group_name      = azurerm_resource_group.rg-central-india-gecko-t.name
+  location                 = "Central India"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "sacentralindiageckot"
+    })
+  )
+}
+
+resource "azurerm_network_security_group" "nsg-central-india-gecko-t" {
+  name                = "nsg-central-india-gecko-t"
+  location            = "Central India"
+  resource_group_name      = azurerm_resource_group.rg-central-india-gecko-t.name
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "nsg-central-india-gecko-t"
+    })
+  )
+}
+resource "azurerm_virtual_network" "vn-central-india-gecko-t" {
+  name                = "vn-central-india-gecko-t"
+  location            = "Central India"
+  resource_group_name      = azurerm_resource_group.rg-central-india-gecko-t.name
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  subnet {
+    name           = "sn-central-india-gecko-t"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.nsg-central-india-gecko-t.id
+  }
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "vn-central-india-gecko-t"
+    })
+  )
+}
+
 resource "azurerm_resource_group" "rg-central-us-gecko-t" {
   name     = "rg-central-us-gecko-t"
   location = "Central US"
@@ -48,56 +151,6 @@ resource "azurerm_virtual_network" "vn-central-us-gecko-t" {
   )
 }
 
-resource "azurerm_resource_group" "rg-east-us-2-gecko-t" {
-  name     = "rg-east-us-2-gecko-t"
-  location = "East US 2"
-  tags = merge(local.common_tags,
-    tomap({
-      "Name" = "rg-east-us-2-gecko-t"
-    })
-  )
-}
-# storage account names can only consist of lowercase letters and numbers
-resource "azurerm_storage_account" "saeastus2geckot" {
-  name                     = "saeastus2geckot"
-  resource_group_name      = azurerm_resource_group.rg-east-us-2-gecko-t.name
-  location                 = "East US 2"
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
-  tags = merge(local.common_tags,
-    tomap({
-      "Name" = "saeastus2geckot"
-    })
-  )
-}
-resource "azurerm_network_security_group" "nsg-east-us-2-gecko-t" {
-  name                = "nsg-east-us-2-gecko-t"
-  location            = "East US 2"
-  resource_group_name = azurerm_resource_group.rg-east-us-2-gecko-t.name
-  tags = merge(local.common_tags,
-    tomap({
-      "Name" = "nsg-east-us-2-gecko-t"
-    })
-  )
-}
-resource "azurerm_virtual_network" "vn-east-us-2-gecko-t" {
-  name                = "vn-east-us-2-gecko-t"
-  location            = "East US 2"
-  resource_group_name = azurerm_resource_group.rg-east-us-2-gecko-t.name
-  address_space       = ["10.0.0.0/24"]
-  dns_servers         = ["1.1.1.1", "1.1.1.0"]
-  subnet {
-    name           = "sn-east-us-2-gecko-t"
-    address_prefix = "10.0.0.0/24"
-    security_group = azurerm_network_security_group.nsg-east-us-2-gecko-t.id
-  }
-  tags = merge(local.common_tags,
-    tomap({
-      "Name" = "vn-east-us-2-gecko-t"
-    })
-  )
-}
-
 resource "azurerm_resource_group" "rg-east-us-gecko-t" {
   name     = "rg-east-us-gecko-t"
   location = "East US"
@@ -144,6 +197,56 @@ resource "azurerm_virtual_network" "vn-east-us-gecko-t" {
   tags = merge(local.common_tags,
     tomap({
       "Name" = "vn-east-us-gecko-t"
+    })
+  )
+}
+
+resource "azurerm_resource_group" "rg-east-us-2-gecko-t" {
+  name     = "rg-east-us-2-gecko-t"
+  location = "East US 2"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "rg-east-us-2-gecko-t"
+    })
+  )
+}
+# storage account names can only consist of lowercase letters and numbers
+resource "azurerm_storage_account" "saeastus2geckot" {
+  name                     = "saeastus2geckot"
+  resource_group_name      = azurerm_resource_group.rg-east-us-2-gecko-t.name
+  location                 = "East US 2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "saeastus2geckot"
+    })
+  )
+}
+resource "azurerm_network_security_group" "nsg-east-us-2-gecko-t" {
+  name                = "nsg-east-us-2-gecko-t"
+  location            = "East US 2"
+  resource_group_name = azurerm_resource_group.rg-east-us-2-gecko-t.name
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "nsg-east-us-2-gecko-t"
+    })
+  )
+}
+resource "azurerm_virtual_network" "vn-east-us-2-gecko-t" {
+  name                = "vn-east-us-2-gecko-t"
+  location            = "East US 2"
+  resource_group_name = azurerm_resource_group.rg-east-us-2-gecko-t.name
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  subnet {
+    name           = "sn-east-us-2-gecko-t"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.nsg-east-us-2-gecko-t.id
+  }
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "vn-east-us-2-gecko-t"
     })
   )
 }
@@ -244,6 +347,57 @@ resource "azurerm_virtual_network" "vn-north-europe-gecko-t" {
   tags = merge(local.common_tags,
     tomap({
       "Name" = "vn-north-europe-gecko-t"
+    })
+  )
+}
+
+## South India
+resource "azurerm_resource_group" "rg-south-india-gecko-t" {
+  name     = "rg-south-india-gecko-t"
+  location = "South India"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "rg-south-india-gecko-t"
+    })
+  )
+}
+# storage account names can only consist of lowercase letters and numbers
+resource "azurerm_storage_account" "sasouthindiageckot" {
+  name                     = "sasouthindiageckot"
+  resource_group_name      = azurerm_resource_group.rg-south-india-gecko-t.name
+  location                 = "South India"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "sasouthindiageckot"
+    })
+  )
+}
+resource "azurerm_network_security_group" "nsg-south-india-gecko-t" {
+  name                = "nsg-south-india-gecko-t"
+  location            = "South India"
+  resource_group_name = azurerm_resource_group.rg-south-india-gecko-t.name
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "nsg-south-india-gecko-t"
+    })
+  )
+}
+resource "azurerm_virtual_network" "vn-south-india-gecko-t" {
+  name                = "vn-south-india-gecko-t"
+  location            = "South India"
+  resource_group_name = azurerm_resource_group.rg-south-india-gecko-t.name
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  subnet {
+    name           = "sn-south-india-gecko-t"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.nsg-south-india-gecko-t.id
+  }
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "vn-south-india-gecko-t"
     })
   )
 }
@@ -444,6 +598,56 @@ resource "azurerm_virtual_network" "vn-west-us-gecko-t" {
   tags = merge(local.common_tags,
     tomap({
       "Name" = "vn-west-us-gecko-t"
+    })
+  )
+}
+
+resource "azurerm_resource_group" "rg-west-us-3-gecko-t" {
+  name     = "rg-west-us-3-gecko-t"
+  location = "West US 3"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "rg-west-us-3-gecko-t"
+    })
+  )
+}
+# storage account names can only consist of lowercase letters and numbers
+resource "azurerm_storage_account" "sawestus3geckot" {
+  name                     = "sawestus3geckot"
+  resource_group_name      = azurerm_resource_group.rg-west-us-3-gecko-t.name
+  location                 = "West US 3"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "sawestus3geckot"
+    })
+  )
+}
+resource "azurerm_network_security_group" "nsg-west-us-3-gecko-t" {
+  name                = "nsg-west-us-3-gecko-t"
+  location            = "West US 3"
+  resource_group_name = azurerm_resource_group.rg-west-us-3-gecko-t.name
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "nsg-west-us-3-gecko-t"
+    })
+  )
+}
+resource "azurerm_virtual_network" "vn-west-us-3-gecko-t" {
+  name                = "vn-west-us-3-gecko-t"
+  location            = "West US 3"
+  resource_group_name = azurerm_resource_group.rg-west-us-3-gecko-t.name
+  address_space       = ["10.0.0.0/24"]
+  dns_servers         = ["1.1.1.1", "1.1.1.0"]
+  subnet {
+    name           = "sn-west-us-3-gecko-t"
+    address_prefix = "10.0.0.0/24"
+    security_group = azurerm_network_security_group.nsg-west-us-3-gecko-t.id
+  }
+  tags = merge(local.common_tags,
+    tomap({
+      "Name" = "vn-west-us-3-gecko-t"
     })
   )
 }


### PR DESCRIPTION
Adding more regions:

```
Terraform will perform the following actions:

  # azurerm_network_security_group.nsg-canada-central-gecko-t will be created
  + resource "azurerm_network_security_group" "nsg-canada-central-gecko-t" {
      + id                  = (known after apply)
      + location            = "canadacentral"
      + name                = "nsg-canada-central-gecko-t"
      + resource_group_name = "rg-canada-central-gecko-t"
      + security_rule       = (known after apply)
      + tags                = {
          + "Name"             = "nsg-canada-central-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_network_security_group.nsg-central-india-gecko-t will be created
  + resource "azurerm_network_security_group" "nsg-central-india-gecko-t" {
      + id                  = (known after apply)
      + location            = "centralindia"
      + name                = "nsg-central-india-gecko-t"
      + resource_group_name = "rg-central-india-gecko-t"
      + security_rule       = (known after apply)
      + tags                = {
          + "Name"             = "nsg-central-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_network_security_group.nsg-south-india-gecko-t will be created
  + resource "azurerm_network_security_group" "nsg-south-india-gecko-t" {
      + id                  = (known after apply)
      + location            = "southindia"
      + name                = "nsg-south-india-gecko-t"
      + resource_group_name = "rg-south-india-gecko-t"
      + security_rule       = (known after apply)
      + tags                = {
          + "Name"             = "nsg-south-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_network_security_group.nsg-west-us-3-gecko-t will be created
  + resource "azurerm_network_security_group" "nsg-west-us-3-gecko-t" {
      + id                  = (known after apply)
      + location            = "westus3"
      + name                = "nsg-west-us-3-gecko-t"
      + resource_group_name = "rg-west-us-3-gecko-t"
      + security_rule       = (known after apply)
      + tags                = {
          + "Name"             = "nsg-west-us-3-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_resource_group.rg-canada-central-gecko-t will be created
  + resource "azurerm_resource_group" "rg-canada-central-gecko-t" {
      + id       = (known after apply)
      + location = "canadacentral"
      + name     = "rg-canada-central-gecko-t"
      + tags     = {
          + "Name"             = "rg-canada-central-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_resource_group.rg-central-india-gecko-t will be created
  + resource "azurerm_resource_group" "rg-central-india-gecko-t" {
      + id       = (known after apply)
      + location = "centralindia"
      + name     = "rg-central-india-gecko-t"
      + tags     = {
          + "Name"             = "rg-central-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_resource_group.rg-south-india-gecko-t will be created
  + resource "azurerm_resource_group" "rg-south-india-gecko-t" {
      + id       = (known after apply)
      + location = "southindia"
      + name     = "rg-south-india-gecko-t"
      + tags     = {
          + "Name"             = "rg-south-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_resource_group.rg-west-us-3-gecko-t will be created
  + resource "azurerm_resource_group" "rg-west-us-3-gecko-t" {
      + id       = (known after apply)
      + location = "westus3"
      + name     = "rg-west-us-3-gecko-t"
      + tags     = {
          + "Name"             = "rg-west-us-3-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_storage_account.sacanadacentralgeckot will be created
  + resource "azurerm_storage_account" "sacanadacentralgeckot" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "GRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "canadacentral"
      + min_tls_version                   = "TLS1_2"
      + name                              = "sacanadacentralgeckot"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-canada-central-gecko-t"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "Name"             = "sacanadacentralgeckot"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_storage_account.sacentralindiageckot will be created
  + resource "azurerm_storage_account" "sacentralindiageckot" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "GRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "centralindia"
      + min_tls_version                   = "TLS1_2"
      + name                              = "sacentralindiageckot"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-central-india-gecko-t"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "Name"             = "sacentralindiageckot"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_storage_account.sasouthindiageckot will be created
  + resource "azurerm_storage_account" "sasouthindiageckot" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "GRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "southindia"
      + min_tls_version                   = "TLS1_2"
      + name                              = "sasouthindiageckot"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-south-india-gecko-t"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "Name"             = "sasouthindiageckot"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_storage_account.sawestus3geckot will be created
  + resource "azurerm_storage_account" "sawestus3geckot" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "GRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "westus3"
      + min_tls_version                   = "TLS1_2"
      + name                              = "sawestus3geckot"
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-west-us-3-gecko-t"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "Name"             = "sawestus3geckot"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }

      + blob_properties {
          + change_feed_enabled           = (known after apply)
          + change_feed_retention_in_days = (known after apply)
          + default_service_version       = (known after apply)
          + last_access_time_enabled      = (known after apply)
          + versioning_enabled            = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # azurerm_virtual_network.vn-canada-central-gecko-t will be created
  + resource "azurerm_virtual_network" "vn-canada-central-gecko-t" {
      + address_space       = [
          + "10.0.0.0/24",
        ]
      + dns_servers         = [
          + "1.1.1.1",
          + "1.1.1.0",
        ]
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "canadacentral"
      + name                = "vn-canada-central-gecko-t"
      + resource_group_name = "rg-canada-central-gecko-t"
      + subnet              = [
          + {
              + address_prefix = "10.0.0.0/24"
              + id             = (known after apply)
              + name           = "sn-canada-central-gecko-t"
              + security_group = (known after apply)
            },
        ]
      + tags                = {
          + "Name"             = "vn-canada-central-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_virtual_network.vn-central-india-gecko-t will be created
  + resource "azurerm_virtual_network" "vn-central-india-gecko-t" {
      + address_space       = [
          + "10.0.0.0/24",
        ]
      + dns_servers         = [
          + "1.1.1.1",
          + "1.1.1.0",
        ]
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "centralindia"
      + name                = "vn-central-india-gecko-t"
      + resource_group_name = "rg-central-india-gecko-t"
      + subnet              = [
          + {
              + address_prefix = "10.0.0.0/24"
              + id             = (known after apply)
              + name           = "sn-central-india-gecko-t"
              + security_group = (known after apply)
            },
        ]
      + tags                = {
          + "Name"             = "vn-central-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_virtual_network.vn-south-india-gecko-t will be created
  + resource "azurerm_virtual_network" "vn-south-india-gecko-t" {
      + address_space       = [
          + "10.0.0.0/24",
        ]
      + dns_servers         = [
          + "1.1.1.1",
          + "1.1.1.0",
        ]
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "southindia"
      + name                = "vn-south-india-gecko-t"
      + resource_group_name = "rg-south-india-gecko-t"
      + subnet              = [
          + {
              + address_prefix = "10.0.0.0/24"
              + id             = (known after apply)
              + name           = "sn-south-india-gecko-t"
              + security_group = (known after apply)
            },
        ]
      + tags                = {
          + "Name"             = "vn-south-india-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

  # azurerm_virtual_network.vn-west-us-3-gecko-t will be created
  + resource "azurerm_virtual_network" "vn-west-us-3-gecko-t" {
      + address_space       = [
          + "10.0.0.0/24",
        ]
      + dns_servers         = [
          + "1.1.1.1",
          + "1.1.1.0",
        ]
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "westus3"
      + name                = "vn-west-us-3-gecko-t"
      + resource_group_name = "rg-west-us-3-gecko-t"
      + subnet              = [
          + {
              + address_prefix = "10.0.0.0/24"
              + id             = (known after apply)
              + name           = "sn-west-us-3-gecko-t"
              + security_group = (known after apply)
            },
        ]
      + tags                = {
          + "Name"             = "vn-west-us-3-gecko-t"
          + "owner_email"      = "mcornmesser@mozilla.com"
          + "production_state" = "production"
          + "project_name"     = "azure_fxci"
          + "source_repo_url"  = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
          + "terraform"        = "true"
        }
    }

Plan: 16 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```