### PR TITLE
unschedule nv6 runbook.

### DIFF
--- a/terraform/azure_fxci/rg-central-us-runbooks.tf
+++ b/terraform/azure_fxci/rg-central-us-runbooks.tf
@@ -142,28 +142,6 @@ resource "azurerm_automation_job_schedule" "vm_day_audit" {
 data "local_file" "nv6_audit_delete_ps1" {
   filename = "runbooks/nv6_audit_delete.ps1"
 }
-resource "azurerm_automation_runbook" "nv6_audit_delete" {
-  name                    = "nv6_audit_delete"
-  location                = azurerm_automation_account.resource-monitor.location
-  resource_group_name     = azurerm_automation_account.resource-monitor.resource_group_name
-  automation_account_name = azurerm_automation_account.resource-monitor.name
-  log_verbose             = "false"
-  log_progress            = "true"
-  description             = "Audit and delete oldNV6 VMs"
-  runbook_type            = "PowerShell"
-  content                 = data.local_file.nv6_audit_delete_ps1.content
-  tags = merge(local.common_tags,
-    tomap({
-      "Name" = "nv6_audit_delete"
-    })
-  )
-}
-resource "azurerm_automation_job_schedule" "nv6_audit_delete" {
-  resource_group_name     = azurerm_automation_account.resource-monitor.resource_group_name
-  automation_account_name = azurerm_automation_account.resource-monitor.name
-  schedule_name           = azurerm_automation_schedule.every-4-hours.name
-  runbook_name            = azurerm_automation_runbook.vm_day_audit.name
-}
 data "local_file" "worker_scanner_helper_ps1" {
   filename = "runbooks/worker_scanner_helper.ps1"
 }

--- a/terraform/azure_fxci/runbooks/worker_scanner_helper.ps1
+++ b/terraform/azure_fxci/runbooks/worker_scanner_helper.ps1
@@ -22,15 +22,15 @@ foreach ($nic in $old_nics) {
 	if ((!($nic.MacAddress -like $null)) -and ($nic.ResourceGroupName -eq $target_group)) {
 		$nic_object = Get-AzNetworkInterface -Name $nic.Name -ResourceGroupName $nic.ResourceGroupName
 		$pIP = ($nic.IpConfigurations.PublicIpAddress.Id -replace $pip_prefix )
-		
-		write-output ('Removing NIC and configuration for {0}' -f $nic.Name) 
-		write-output ('Will remove Public IP: {0}' -f $pIP)
-		write-output "$null" 
+
+		write-output ('Removing NIC and configuration for {0}' -f $nic.Name)
+		#write-output ('Will remove Public IP: {0}' -f $pIP)
+		write-output "$null"
 		Remove-AzNetworkInterfaceIpConfig  -Name IPConfig-1 -NetworkInterface $nic_object
 		Remove-AzNetworkInterface -Name $nic.Name -ResourceGroup $nic.ResourceGroupName -force
-		Remove-AzPublicIpAddress -Name $pIP -ResourceGroup $nic.ResourceGroupName -force
+		#Remove-AzPublicIpAddress -Name $pIP -ResourceGroup $nic.ResourceGroupName -force
 		$n = ($n +1)
-	}	
+	}
 }
 
 write-output "Removing unattached disks"
@@ -41,7 +41,7 @@ foreach ($md in $managedDisks) {
 		write-output ('Deleting Disk with Id: {0}' -f $md.Id)
 		write-output "$null"
 		$md | Remove-AzDisk -Force
-		
+
 		$d = ($d + 2)
     }
  }


### PR DESCRIPTION
The nv6 runbook is no longer needed. 

Do not attempt to remove public IPs in the worker-manager helper script. Public IPs are no longer provisioned. Commented out if in case this changes int he future. 

Applied without error. 