### PR TITLE
Create azure service principal for use with packer

### DIFF
--- a/terraform/azure_ad/sp_packer_worker_images.tf
+++ b/terraform/azure_ad/sp_packer_worker_images.tf
@@ -1,0 +1,52 @@
+data "azuread_group" "relops" {
+  display_name = "relops"
+}
+
+# application: worker_images_dev
+resource "azuread_application" "worker_images_dev" {
+  display_name = "worker_images_dev"
+  homepage     = "https://github.com/mozilla-platform-ops/worker-images"
+  owners       = [data.azuread_group.relops.id]
+}
+
+resource "azuread_service_principal" "worker_images_dev" {
+  application_id = azuread_application.worker_images_dev.application_id
+}
+
+resource "azurerm_role_assignment" "worker_images_dev" {
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.worker_images_dev.object_id
+  scope                = "/subscriptions/0a420ff9-bc77-4475-befc-a05071fc92ec"
+}
+
+resource "azuread_application" "worker_images_fxci" {
+  display_name = "worker_images_fxci"
+  homepage     = "https://github.com/mozilla-platform-ops/worker-images"
+  owners       = [data.azuread_group.relops.id]
+}
+
+resource "azuread_service_principal" "worker_images_fxci" {
+  application_id = azuread_application.worker_images_fxci.application_id
+}
+
+resource "azurerm_role_assignment" "worker_images_fxci" {
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.worker_images_fxci.object_id
+  scope                = "/subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0"
+}
+
+resource "azuread_application" "worker_images_fxci_trusted" {
+  display_name = "worker_images_fxci_trusted"
+  homepage     = "https://github.com/mozilla-platform-ops/worker-images"
+  owners       = [data.azuread_group.relops.id]
+}
+
+resource "azuread_service_principal" "worker_images_fxci_trusted" {
+  application_id = azuread_application.worker_images_fxci_trusted.application_id
+}
+
+resource "azurerm_role_assignment" "worker_images_fxci_trusted" {
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.worker_images_fxci_trusted.object_id
+  scope                = "/subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701"
+}


### PR DESCRIPTION
Plan output:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # azuread_application.worker_images_dev will be created
  + resource "azuread_application" "worker_images_dev" {
      + app_role                = (known after apply)
      + application_id          = (known after apply)
      + display_name            = "worker_images_dev"
      + homepage                = "https://github.com/mozilla-platform-ops/worker-images"
      + id                      = (known after apply)
      + identifier_uris         = (known after apply)
      + name                    = (known after apply)
      + oauth2_permissions      = (known after apply)
      + object_id               = (known after apply)
      + owners                  = [
          + "cb79b99f-fdaa-4e0d-a2c8-c5841890fa74",
        ]
      + prevent_duplicate_names = false
      + public_client           = (known after apply)
      + reply_urls              = (known after apply)
      + type                    = "webapp/api"
    }

  # azuread_application.worker_images_fxci will be created
  + resource "azuread_application" "worker_images_fxci" {
      + app_role                = (known after apply)
      + application_id          = (known after apply)
      + display_name            = "worker_images_fxci"
      + homepage                = "https://github.com/mozilla-platform-ops/worker-images"
      + id                      = (known after apply)
      + identifier_uris         = (known after apply)
      + name                    = (known after apply)
      + oauth2_permissions      = (known after apply)
      + object_id               = (known after apply)
      + owners                  = [
          + "cb79b99f-fdaa-4e0d-a2c8-c5841890fa74",
        ]
      + prevent_duplicate_names = false
      + public_client           = (known after apply)
      + reply_urls              = (known after apply)
      + type                    = "webapp/api"
    }

  # azuread_application.worker_images_fxci_trusted will be created
  + resource "azuread_application" "worker_images_fxci_trusted" {
      + app_role                = (known after apply)
      + application_id          = (known after apply)
      + display_name            = "worker_images_fxci_trusted"
      + homepage                = "https://github.com/mozilla-platform-ops/worker-images"
      + id                      = (known after apply)
      + identifier_uris         = (known after apply)
      + name                    = (known after apply)
      + oauth2_permissions      = (known after apply)
      + object_id               = (known after apply)
      + owners                  = [
          + "cb79b99f-fdaa-4e0d-a2c8-c5841890fa74",
        ]
      + prevent_duplicate_names = false
      + public_client           = (known after apply)
      + reply_urls              = (known after apply)
      + type                    = "webapp/api"
    }

  # azuread_service_principal.worker_images_dev will be created
  + resource "azuread_service_principal" "worker_images_dev" {
      + app_roles      = (known after apply)
      + application_id = (known after apply)
      + display_name   = (known after apply)
      + id             = (known after apply)
      + object_id      = (known after apply)

      + oauth2_permissions {
          + admin_consent_description  = (known after apply)
          + admin_consent_display_name = (known after apply)
          + id                         = (known after apply)
          + is_enabled                 = (known after apply)
          + type                       = (known after apply)
          + user_consent_description   = (known after apply)
          + user_consent_display_name  = (known after apply)
          + value                      = (known after apply)
        }
    }

  # azuread_service_principal.worker_images_fxci will be created
  + resource "azuread_service_principal" "worker_images_fxci" {
      + app_roles      = (known after apply)
      + application_id = (known after apply)
      + display_name   = (known after apply)
      + id             = (known after apply)
      + object_id      = (known after apply)

      + oauth2_permissions {
          + admin_consent_description  = (known after apply)
          + admin_consent_display_name = (known after apply)
          + id                         = (known after apply)
          + is_enabled                 = (known after apply)
          + type                       = (known after apply)
          + user_consent_description   = (known after apply)
          + user_consent_display_name  = (known after apply)
          + value                      = (known after apply)
        }
    }

  # azuread_service_principal.worker_images_fxci_trusted will be created
  + resource "azuread_service_principal" "worker_images_fxci_trusted" {
      + app_roles      = (known after apply)
      + application_id = (known after apply)
      + display_name   = (known after apply)
      + id             = (known after apply)
      + object_id      = (known after apply)

      + oauth2_permissions {
          + admin_consent_description  = (known after apply)
          + admin_consent_display_name = (known after apply)
          + id                         = (known after apply)
          + is_enabled                 = (known after apply)
          + type                       = (known after apply)
          + user_consent_description   = (known after apply)
          + user_consent_display_name  = (known after apply)
          + value                      = (known after apply)
        }
    }

  # azurerm_role_assignment.worker_images_dev will be created
  + resource "azurerm_role_assignment" "worker_images_dev" {
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Contributor"
      + scope                            = "/subscriptions/0a420ff9-bc77-4475-befc-a05071fc92ec"
      + skip_service_principal_aad_check = (known after apply)
    }

  # azurerm_role_assignment.worker_images_fxci will be created
  + resource "azurerm_role_assignment" "worker_images_fxci" {
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Contributor"
      + scope                            = "/subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0"
      + skip_service_principal_aad_check = (known after apply)
    }

  # azurerm_role_assignment.worker_images_fxci_trusted will be created
  + resource "azurerm_role_assignment" "worker_images_fxci_trusted" {
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Contributor"
      + scope                            = "/subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701"
      + skip_service_principal_aad_check = (known after apply)
    }

Plan: 9 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```