### PR TITLE
Add more shared image gallery definitions

### DIFF
--- a/terraform/azure_fx_nonci/worker-images.tf
+++ b/terraform/azure_fx_nonci/worker-images.tf
@@ -36,8 +36,38 @@ resource "azurerm_shared_image" "win11_64_2009" {
   }
 }
 
+resource "azurerm_shared_image" "win11_64_2009_alpha" {
+  name                = "win11-64-2009-alpha"
+  gallery_name        = azurerm_shared_image_gallery.packer.name
+  resource_group_name = azurerm_resource_group.rg-packer-worker-images.name
+  location            = azurerm_resource_group.rg-packer-worker-images.location
+  os_type             = "Windows"
+  hyper_v_generation  = "V2"
+
+  identifier {
+    publisher = "MicrosoftWindowsDesktop"
+    offer     = "Windows-11"
+    sku       = "win11-22h2-avd"
+  }
+}
+
 resource "azurerm_shared_image" "win10_64_2009" {
   name                = "win10-64-2009"
+  gallery_name        = azurerm_shared_image_gallery.packer.name
+  resource_group_name = azurerm_resource_group.rg-packer-worker-images.name
+  location            = azurerm_resource_group.rg-packer-worker-images.location
+  os_type             = "Windows"
+  hyper_v_generation  = "V2"
+
+  identifier {
+    publisher = "MicrosoftWindowsDesktop"
+    offer     = "Windows-10"
+    sku       = "win10-22h2-avd"
+  }
+}
+
+resource "azurerm_shared_image" "win10_64_2009_alpha" {
+  name                = "win10-64-2009-alpha"
   gallery_name        = azurerm_shared_image_gallery.packer.name
   resource_group_name = azurerm_resource_group.rg-packer-worker-images.name
   location            = azurerm_resource_group.rg-packer-worker-images.location


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # azurerm_shared_image.win10_64_2009_alpha will be created
  + resource "azurerm_shared_image" "win10_64_2009_alpha" {
      + gallery_name        = "workerimages"
      + hyper_v_generation  = "V2"
      + id                  = (known after apply)
      + location            = "centralus"
      + name                = "win10-64-2009-alpha"
      + os_type             = "Windows"
      + resource_group_name = "rg-packer-worker-images"

      + identifier {
          + offer     = "Windows-10"
          + publisher = "MicrosoftWindowsDesktop"
          + sku       = "win10-22h2-avd"
        }
    }

  # azurerm_shared_image.win11_64_2009_alpha will be created
  + resource "azurerm_shared_image" "win11_64_2009_alpha" {
      + gallery_name        = "workerimages"
      + hyper_v_generation  = "V2"
      + id                  = (known after apply)
      + location            = "centralus"
      + name                = "win11-64-2009-alpha"
      + os_type             = "Windows"
      + resource_group_name = "rg-packer-worker-images"

      + identifier {
          + offer     = "Windows-11"
          + publisher = "MicrosoftWindowsDesktop"
          + sku       = "win11-22h2-avd"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```