### PR TITLE
circleci docker image update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.82.0
+  rev: v1.83.2
   hooks:
     - id: terraform_fmt
       args:

--- a/docker/dockerfiles/circleci-ubuntu-2204/Dockerfile
+++ b/docker/dockerfiles/circleci-ubuntu-2204/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+RUN apt-get update
+RUN apt-get -y install shellcheck git curl unzip python3-pip ruby-full
+RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile
+RUN PATH="$HOME/.tfenv/bin:$PATH" tfenv install 1.5.7
+RUN pip3 install pre-commit

--- a/docker/dockerfiles/circleci-ubuntu-2204/Dockerfile
+++ b/docker/dockerfiles/circleci-ubuntu-2204/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04
 RUN apt-get update
-RUN apt-get -y install shellcheck git curl unzip python3-pip ruby-full
+RUN apt-get -y install shellcheck git curl unzip python3-pip ruby-full bash
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile
 RUN PATH="$HOME/.tfenv/bin:$PATH" tfenv install 1.5.7
 RUN pip3 install pre-commit
+ENTRYPOINT /bin/bash

--- a/docker/dockerfiles/circleci-ubuntu-2204/README.md
+++ b/docker/dockerfiles/circleci-ubuntu-2204/README.md
@@ -1,10 +1,19 @@
 # circleci-ubuntu-2004
 
-used to generate https://hub.docker.com/repository/docker/mozillarelops/circleci-ubuntu-2004
+used to generate https://hub.docker.com/repository/docker/mozillarelops/circleci-ubuntu-2204
 
-## publishing
+## build, test, publish process
 
+```shell
+# build
+docker build . --platform linux/amd64 -t mozillarelops/circleci-ubuntu-2204(:VERSION_TAG_GOES_HERE)
+
+# get a shell and test
+docker run -it --platform linux/amd64 mozillarelops/circleci-ubuntu-2204
+# inspect
+docker image inspect mozillarelops/circleci-ubuntu-2204
+
+# publish
+docker push mozillarelops/circleci-ubuntu-2204:VERSION_TAG_GOES_HERE
 ```
 
-
-```

--- a/docker/dockerfiles/circleci-ubuntu-2204/README.md
+++ b/docker/dockerfiles/circleci-ubuntu-2204/README.md
@@ -1,0 +1,10 @@
+# circleci-ubuntu-2004
+
+used to generate https://hub.docker.com/repository/docker/mozillarelops/circleci-ubuntu-2004
+
+## publishing
+
+```
+
+
+```

--- a/docker/dockerfiles/circleci-ubuntu-2204/README.md
+++ b/docker/dockerfiles/circleci-ubuntu-2204/README.md
@@ -6,14 +6,20 @@ used to generate https://hub.docker.com/repository/docker/mozillarelops/circleci
 
 ```shell
 # build
-docker build . --platform linux/amd64 -t mozillarelops/circleci-ubuntu-2204(:VERSION_TAG_GOES_HERE)
+docker build . --platform linux/amd64 -t mozillarelops/circleci-ubuntu-2204:latest
 
 # get a shell and test
 docker run -it --platform linux/amd64 mozillarelops/circleci-ubuntu-2204
 # inspect
 docker image inspect mozillarelops/circleci-ubuntu-2204
 
-# publish
-docker push mozillarelops/circleci-ubuntu-2204:VERSION_TAG_GOES_HERE
+# publish latest
+# TODO: publish to beta (vs latest)
+docker push mozillarelops/circleci-ubuntu-2204:latest
+
+# publish version if it looks good
+# - version tags are like v0.0.1
+docker tag mozillarelops/circleci-ubuntu-2204:latest mozillarelops/circleci-ubuntu-2204:VERSION_TAG
+docker push mozillarelops/circleci-ubuntu-2204:VERSION_TAG
 ```
 


### PR DESCRIPTION
Create new 22.04 image used in CI. Used in https://github.com/mozilla-platform-ops/snakepit_puppet/pull/8 initially.

Published at https://hub.docker.com/repository/docker/mozillarelops/circleci-ubuntu-2204.