### PR TITLE
tf: fxci production level1 workers: add permissions for releng and translations

### DIFF
--- a/terraform/base/tf_state_lock_gcp-fxci-production-level1-workers.tf
+++ b/terraform/base/tf_state_lock_gcp-fxci-production-level1-workers.tf
@@ -1,0 +1,19 @@
+resource "aws_dynamodb_table" "tf_state_lock_gcp-fxci-production-level1-workers" {
+  name           = "tf_state_lock_gcp-fxci-production-level1-workers"
+  hash_key       = "LockID"
+  read_capacity  = 20
+  write_capacity = 20
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "gcp-fxci-production-level1-workers Terraform State Lock Table"
+    Terraform   = "true"
+    Repo_url    = var.repo_url
+    Environment = "prod"
+    Owner       = "relops@mozilla.com"
+  }
+}

--- a/terraform/create_state.sh
+++ b/terraform/create_state.sh
@@ -4,7 +4,6 @@ set -e
 #set -x
 
 # TODO: provide user with a `tf apply -target` command that will avoid the risk of deletions
-# TODO: create terraform.tfvars with the module name set?
 
 function usage ()
 {
@@ -49,6 +48,15 @@ terraform {
     region         = "us-west-2"
   }
 }
+EOF
+
+echo "Generating ${STATE_NAME}/terraform.tfvars"
+cat <<EOF >"${STATE_NAME}/terraform.tfvars"
+tag_project_name = "${STATE_NAME}"
+
+tag_production_state = "production"
+
+tag_owner_email = "${USER}@mozilla.com"
 EOF
 
 echo "Generating base/tf_state_lock_${STATE_NAME}.tf"

--- a/terraform/gcp-fxci-production-level1-workers/.terraform.lock.hcl
+++ b/terraform/gcp-fxci-production-level1-workers/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.19.0"
+  hashes = [
+    "h1:MJclj56jijp7T4V4g5tzHXS3M8vUdJAcBRjEstBh0Hc=",
+    "zh:03aa0f857c6dfce5f46c9bf3aad45534b9421e68983994b6f9dd9812beaece9c",
+    "zh:0639818c5bf9f9943667f39ec38bb945c9786983025dff407390133fa1ca5041",
+    "zh:0b82ad42ced8fb4a138eaf2fd37cf6059ca0bb482114b35fb84f22fc1500324a",
+    "zh:173e8c19a9f1d8f6457c80f4a73a92f420a81d650fc4ad0f97a5dc4b9485bba8",
+    "zh:42913a40ddfe9b4f3c78ad2e3cdc1dcfd48151bc132dc6b49fc32cd6da79db21",
+    "zh:452db5caca2e53d5f7090979d518e77aa5fd98385514b11ee2ce76a46e89cb53",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a12377ade89ee18d9be116436e411e8396898bd70b21ab027c161c785e86238d",
+    "zh:aa9e4746ba49044ad5b4dda57fcdba7bc16fe65f696766fb2c55c30a27abf844",
+    "zh:adfaee76d283f1c321fad2e4154be88d57da8c2ecfdca9516c8920bd2ece36ed",
+    "zh:bf6fbc6d60661c03ed2214173c1deced908dc62480dd41e67ac399fa4abd7467",
+    "zh:cb685da03ad00d1a27891f3d366d75e8795ac81f1b427888b434e6832ca40633",
+    "zh:e0432c78dfaf2baebe2bf5c0ad8087f547c69c2c5a00e4c1dcd5a6344ce726df",
+    "zh:e0ec9ccb8d34d6d0d8bf7f8628c223951832b4d50ea8887fc711fa854b3a28b4",
+    "zh:f274397ada4ef3c1dce2f70e719c8ccf19fc4e7a2e3f45d018764c6267fd7157",
+  ]
+}

--- a/terraform/gcp-fxci-production-level1-workers/.terraform.lock.hcl
+++ b/terraform/gcp-fxci-production-level1-workers/.terraform.lock.hcl
@@ -22,3 +22,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f274397ada4ef3c1dce2f70e719c8ccf19fc4e7a2e3f45d018764c6267fd7157",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "5.1.0"
+  hashes = [
+    "h1:76HT6nyFNWu7v1+VSIRwrs45hH7z8iZR23W8jon5K+Q=",
+    "zh:01f24868bba2292a097cb7d754b41a660050475235c07ceddeceaa8f2a19f6d8",
+    "zh:184182ec28d6aec21531001092e276f1ea1b1b6ad2bba7e632bc56c5d6f2ec77",
+    "zh:2fb6762046649acb625bb7c8e9955eaca2e64ecebd1313c5e843c957ddfa9d2f",
+    "zh:38178391ae9444c1c6b77489d6afcbf4ec30be733ae4d88b94b1c1d800ae706a",
+    "zh:49d2c57cd6c82336ddebe8ecb7ee0d6882b276b7ba32c62d82828c4530088c22",
+    "zh:73eecd0d8dc45b5c3ebb3adce16761c84c7048f7fa70088ad7ac30641381edd9",
+    "zh:81bd96748be1a4abac25fb6ae93cd6b84a10ed4b03435405df7ccbc38a1e8053",
+    "zh:882ac45a7a3e1cce1eabef5be28d66c2eed9fc881a81c9dcc66b863a1e0d829c",
+    "zh:9141b04c8bdf079f0e82b750ab090a7ab20a56975906b7fae76434ea5cc71b5f",
+    "zh:9369ed15e686807422b30958bf84860d9b4f112aee0173a1e6367f056f8e4c97",
+    "zh:e83e5ede7f74206a13310d29d4b6599e9ed54fa4b86427d15332de10630848dc",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/gcp-fxci-production-level1-workers/README.md
+++ b/terraform/gcp-fxci-production-level1-workers/README.md
@@ -1,0 +1,9 @@
+# fxci-production-level1-workers
+
+## applying
+
+```bash
+export GOOGLE_CLOUD_KEYFILE_JSON=~/.gcp_credentials/BLAH
+gcloud auth application-default login
+tf apply
+```

--- a/terraform/gcp-fxci-production-level1-workers/backend.tf
+++ b/terraform/gcp-fxci-production-level1-workers/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "relops-tf-states"
+    key            = "gcp-fxci-production-level1-workers.tfstate"
+    dynamodb_table = "tf_state_lock_gcp-fxci-production-level1-workers"
+    region         = "us-west-2"
+  }
+}

--- a/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
+++ b/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
@@ -8,18 +8,47 @@ variable "translations_users" {
     description = "list of usernames"
 }
 
-resource "google_project_iam_member" "releng-users" {
+# TODO: use this?
+# roles/viewer has a ton of permissions, reduce
+#   - https://console.cloud.google.com/iam-admin/roles/details/roles%3Cviewer?project=fxci-production-level1-workers
+# resource "google_organization_iam_custom_role" "relsre-compute-viewer" {
+#   role_id     = "relsre-compute-viewer"
+#   org_id      = "887720501152"  # fxci-production-level1-workers
+#   title       = "ReleaseSRE 'compute viewer' custom role"
+#   description = "a read-only role that allows viewing of compute resources"
+#   permissions = ["compute.instances.list", "compute.instances.get"]
+# }
+
+# roles/monitoring.viewer
+resource "google_project_iam_member" "releng-users-monitoring" {
     for_each = "${var.releng_users}"
 
   project = "fxci-production-level1-workers"
-  role    = "compute.instances.list"
+  role    = "roles/monitoring.viewer"
   member  = "user:${each.value}@mozilla.com"
 }
 
-resource "google_project_iam_member" "translations-users" {
+resource "google_project_iam_member" "translations-users-monitoring" {
     for_each = "${var.releng_users}"
 
   project = "fxci-production-level1-workers"
-  role    = "compute.instances.list"
+  role    = "roles/monitoring.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
+# roles/compute.viewer
+resource "google_project_iam_member" "releng-users-compute" {
+    for_each = "${var.releng_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/compute.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
+resource "google_project_iam_member" "translations-users-compute" {
+    for_each = "${var.releng_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/compute.viewer"
   member  = "user:${each.value}@mozilla.com"
 }

--- a/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
+++ b/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
@@ -1,0 +1,25 @@
+variable "releng_users" {
+    type = set(string)
+    description = "list of usernames"
+}
+
+variable "translations_users" {
+    type = set(string)
+    description = "list of usernames"
+}
+
+resource "google_project_iam_member" "releng-users" {
+    for_each = "${var.releng_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "compute.instances.list"
+  member  = "user:${each.value}@mozilla.com"
+}
+
+resource "google_project_iam_member" "translations-users" {
+    for_each = "${var.releng_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "compute.instances.list"
+  member  = "user:${each.value}@mozilla.com"
+}

--- a/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
+++ b/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
@@ -29,7 +29,7 @@ resource "google_project_iam_member" "releng-users-monitoring" {
 }
 
 resource "google_project_iam_member" "translations-users-monitoring" {
-    for_each = "${var.releng_users}"
+    for_each = "${var.translations_users}"
 
   project = "fxci-production-level1-workers"
   role    = "roles/monitoring.viewer"
@@ -46,7 +46,7 @@ resource "google_project_iam_member" "releng-users-compute" {
 }
 
 resource "google_project_iam_member" "translations-users-compute" {
-    for_each = "${var.releng_users}"
+    for_each = "${var.translations_users}"
 
   project = "fxci-production-level1-workers"
   role    = "roles/compute.viewer"

--- a/terraform/gcp-fxci-production-level1-workers/gcp_provider.tf
+++ b/terraform/gcp-fxci-production-level1-workers/gcp_provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  project = "fxci-production-level1-workers"
+  # not sure what these should be
+  region  = "us-west1"
+  zone    = "us-west1-b"
+}
+

--- a/terraform/gcp-fxci-production-level1-workers/providers.tf
+++ b/terraform/gcp-fxci-production-level1-workers/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/terraform/gcp-fxci-production-level1-workers/resources.tf
+++ b/terraform/gcp-fxci-production-level1-workers/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
+++ b/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
@@ -3,3 +3,6 @@ tag_project_name = "gcp-fxci-production-level1-workers"
 tag_production_state = "production"
 
 tag_owner_email = "aerickson@mozilla.com"
+
+releng_users = ["bhearsum", "gbustamante"]
+translations_users = ["epavlov","gtatum"]

--- a/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
+++ b/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
@@ -1,0 +1,5 @@
+tag_project_name = "gcp-fxci-production-level1-workers"
+
+tag_production_state = "production"
+
+tag_owner_email = "aerickson@mozilla.com"

--- a/terraform/gcp-fxci-production-level1-workers/variables.tf
+++ b/terraform/gcp-fxci-production-level1-workers/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
Has been applied at [bc46f58](https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/147/commits/bc46f58727b8a59930353e28180a5e53150a0793) and [7c1be58](https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/147/commits/7c1be58cef13e2f5e956d23b0af3c94dda5df10a) already. Releng and translations have verified access.

Also:
- create_state.sh creates a terraform.tfvars file now.