### PR TITLE
gcp l1: add logging.viewer for releng and translations

### DIFF
--- a/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
+++ b/terraform/gcp-fxci-production-level1-workers/gcp_iam.tf
@@ -52,3 +52,20 @@ resource "google_project_iam_member" "translations-users-compute" {
   role    = "roles/compute.viewer"
   member  = "user:${each.value}@mozilla.com"
 }
+
+# roles/logging.viewer
+resource "google_project_iam_member" "releng-users-logs" {
+    for_each = "${var.releng_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/logging.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
+resource "google_project_iam_member" "translations-users-logs" {
+    for_each = "${var.translations_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/logging.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}


### PR DESCRIPTION
bhearsum is debugging something and this role would be useful. 

Seems to be within the intent of the RRA we've already done for allowing access to l1 GCP console for releng and translations.

Already applied.