### PR TITLE
upgrade actions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,9 +9,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: hashicorp/setup-terraform@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.5.7
     - name: Run pre-commit
       run: |
         pip install pre-commit


### PR DESCRIPTION
I noticed a warning on https://github.com/mozilla-platform-ops/relops_infra_as_code/actions/runs/8837321346.


> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3, hashicorp/setup-terraform@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
