### PR TITLE
refactor pr #164, clarify non-membership of some users

### DIFF
--- a/terraform/gcp-fxci-production-level1-workers/_compute_read_only_access.tf
+++ b/terraform/gcp-fxci-production-level1-workers/_compute_read_only_access.tf
@@ -1,9 +1,16 @@
+# grants various read-only permissions to releng, translations, and other users
+
 variable "releng_users" {
     type = set(string)
     description = "list of usernames"
 }
 
 variable "translations_users" {
+    type = set(string)
+    description = "list of usernames"
+}
+
+variable "read_only_users" {
     type = set(string)
     description = "list of usernames"
 }
@@ -36,6 +43,14 @@ resource "google_project_iam_member" "translations-users-monitoring" {
   member  = "user:${each.value}@mozilla.com"
 }
 
+resource "google_project_iam_member" "read-only-users-monitoring" {
+    for_each = "${var.read_only_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/monitoring.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
 # roles/compute.viewer
 resource "google_project_iam_member" "releng-users-compute" {
     for_each = "${var.releng_users}"
@@ -53,6 +68,14 @@ resource "google_project_iam_member" "translations-users-compute" {
   member  = "user:${each.value}@mozilla.com"
 }
 
+resource "google_project_iam_member" "read-only-users-compute" {
+    for_each = "${var.read_only_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/compute.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
 # roles/logging.viewer
 resource "google_project_iam_member" "releng-users-logs" {
     for_each = "${var.releng_users}"
@@ -64,6 +87,14 @@ resource "google_project_iam_member" "releng-users-logs" {
 
 resource "google_project_iam_member" "translations-users-logs" {
     for_each = "${var.translations_users}"
+
+  project = "fxci-production-level1-workers"
+  role    = "roles/logging.viewer"
+  member  = "user:${each.value}@mozilla.com"
+}
+
+resource "google_project_iam_member" "read-only-users-logs" {
+    for_each = "${var.read_only_users}"
 
   project = "fxci-production-level1-workers"
   role    = "roles/logging.viewer"
@@ -88,19 +119,10 @@ resource "google_project_iam_member" "translations-users-monitoring-editor" {
   member  = "user:${each.value}@mozilla.com"
 }
 
-# bhearsum wants compute.instances.simulateMaintenanceEvent for spot instance termination testing
+resource "google_project_iam_member" "read-only-users-monitoring-editor" {
+    for_each = "${var.read_only_users}"
 
-# the two pre-existing roles with this perm have too much, create a custom role
-resource "google_project_iam_custom_role" "my-custom-role" {
-  role_id     = "relops_compute_simulate_maintenance"
-  title       = "Relops Compute Simulate Maintenance Role"
-  description = "A role that allows compute.instances.simulateMaintenanceEvent"
-  permissions = ["compute.instances.simulateMaintenanceEvent"]
-}
-
-resource "google_project_iam_member" "bhearsum-compute-simulate-maintenance" {
   project = "fxci-production-level1-workers"
-  # role    = "roles/compute.instances.simulateMaintenanceEvent"
-  role = "projects/fxci-production-level1-workers/roles/relops_compute_simulate_maintenance"
-  member  = "user:bhearsum@mozilla.com"
+  role    = "roles/monitoring.editor"
+  member  = "user:${each.value}@mozilla.com"
 }

--- a/terraform/gcp-fxci-production-level1-workers/_compute_simulate_maintenance_events.tf
+++ b/terraform/gcp-fxci-production-level1-workers/_compute_simulate_maintenance_events.tf
@@ -1,0 +1,16 @@
+# bhearsum wants compute.instances.simulateMaintenanceEvent for spot instance termination testing
+
+# the two pre-existing roles with this perm have too much, create a custom role
+resource "google_project_iam_custom_role" "my-custom-role" {
+  role_id     = "relops_compute_simulate_maintenance"
+  title       = "Relops Compute Simulate Maintenance Role"
+  description = "A role that allows compute.instances.simulateMaintenanceEvent"
+  permissions = ["compute.instances.simulateMaintenanceEvent"]
+}
+
+resource "google_project_iam_member" "bhearsum-compute-simulate-maintenance" {
+  project = "fxci-production-level1-workers"
+  # role    = "roles/compute.instances.simulateMaintenanceEvent"
+  role = "projects/fxci-production-level1-workers/roles/relops_compute_simulate_maintenance"
+  member  = "user:bhearsum@mozilla.com"
+}

--- a/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
+++ b/terraform/gcp-fxci-production-level1-workers/terraform.tfvars
@@ -4,5 +4,6 @@ tag_production_state = "production"
 
 tag_owner_email = "aerickson@mozilla.com"
 
-releng_users = ["bhearsum", "gbustamante", "mcastelluccio", "jlorenzo", "jmaher", "ahalberstadt", "gbrown", "hneiva", "jcristau"]
-translations_users = ["epavlov","gtatum"]
+releng_users = ["bhearsum", "gbustamante", "jlorenzo", "ahalberstadt", "gbrown", "hneiva", "jcristau"]
+translations_users = ["epavlov", "gtatum"]
+read_only_users = ["mcastelluccio", "jmaher"]


### PR DESCRIPTION
Rework this module based on comments in https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/164#pullrequestreview-2056208644 and general usability.

- rename files with _ to help identifying the non-templated files in a module
- rename files to indicate what they do
  - move bhearsum's compute maintenance event simulation rights to separate file
- move mcastelluccio and jmaher to a non-releng group to avoid future confusion
  - add read only rights for this new group

Already terraform applied.