### PR TITLE
Create Entra App to be used in Partner Center

### DIFF
--- a/terraform/azure_ad/sp_ms_store_apitoken_app.tf
+++ b/terraform/azure_ad/sp_ms_store_apitoken_app.tf
@@ -1,0 +1,9 @@
+resource "azuread_application" "ms_store_apitoken_app" {
+  display_name = "MS Store API Token app"
+  owners       = [data.azuread_user.mcornmesser.id]
+}
+
+resource "azuread_service_principal" "ms_store_apitoken_app" {
+  application_id = azuread_application.ms_store_apitoken_app.application_id
+  tags           = concat(["name:ms_store_apitoken_app"], local.sp_tags)
+}


### PR DESCRIPTION
Create app to be used in MS Partner Center to generate store API tokens. The app should have no rights within Entra and will be assigned rights within the Partner Center. 