### PR TITLE
add terraform authoritative scanner

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,4 +19,4 @@ jobs:
     - name: Run pre-commit
       run: |
         pip install pre-commit
-        pre-commit run --all-files
+        pre-commit run --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     - id: shellcheck
 
 - repo: https://github.com/aerickson/tf_authoritative_scanner.git
-  rev: v1.0.2
+  rev: v1.0.3
   hooks:
     - id: tfas

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
   rev: v0.1.22
   hooks:
     - id: shellcheck
+
+- repo: https://github.com/aerickson/tf_authoritative_scanner.git
+  rev: v1.0.2
+  hooks:
+    - id: tfas

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     - id: shellcheck
 
 - repo: https://github.com/aerickson/tf_authoritative_scanner.git
-  rev: v1.0.3
+  rev: v1.0.4
   hooks:
     - id: tfas


### PR DESCRIPTION
Add a tool I wrote (https://github.com/mozilla-platform-ops/tf_authoritative_scanner) to detect authoritative Terraform module usage and fail tests on it.

Example interactive use (just as an example, it's normally run by pre-commit):

```bash
powderdry  relops_infra_as_code git:(9d28089) ✗  ➜  tfas --version
1.0.4
powderdry  relops_infra_as_code git:(9d28089) ✗  ➜  git show -q
# around the commit that caused the outage
commit 9d280890d4ee7ff702ece203729e6722f4600aa1 (HEAD)
Date:   Mon Jul 22 16:36:55 2024 -0400
...
powderdry  relops_infra_as_code git:(9d28089) ✗  ➜  tfas .
AUTHORITATIVE: ./terraform/gcp-fxci-production-level1-workers/github_oidc.tf:10: resource "google_project_iam_binding" "compute_admin" {
AUTHORITATIVE: ./terraform/gcp-fxci-production-level3-workers/github_oidc.tf:10: resource "google_project_iam_binding" "compute_admin" {
FAIL: 2 of 232 scanned files are authoritative.
powderdry  relops_infra_as_code git:(9d28089) ✗  ➜  echo $?
1
powderdry  relops_infra_as_code git:(9d28089) ✗  ➜ 
```