### PR TITLE
add westus3 to gecko-1

### DIFF
--- a/terraform/azure_fxci/local-variables.tf
+++ b/terraform/azure_fxci/local-variables.tf
@@ -30,6 +30,10 @@ variable "gecko1" {
       rgname     = "west-us-2-gecko-1"
       rglocation = "westus2"
     }
+    "rg-west-us-3-gecko-1" = {
+      rgname     = "west-us-3-gecko-1"
+      rglocation = "westus3"
+    }
   }
 }
 


### PR DESCRIPTION
This is part of https://mozilla-hub.atlassian.net/browse/RELOPS-1285. There is currently no west-us-3 resources for gecko-1 provisioner.