### PR TITLE
[RELOPS-591] add osx package blueprints for packages to deliver /etc/puppet_role

### DIFF
--- a/osx_pkg_blueprints/README.md
+++ b/osx_pkg_blueprints/README.md
@@ -1,0 +1,90 @@
+# macOS Package Blueprints for MDM Deployment
+
+This repo contains source blueprints for building and signing macOS `.pkg` installers using [munkipkg](https://github.com/munki/munki-pkg), intended for deployment via MDM (e.g., SimpleMDM, Jamf).
+
+## 📁 Project Layout
+
+```
+osx_pkg_blueprints/
+├── p_role_gecko_t_osx_1400_r8/      # Example package blueprint
+│   ├── build-info.plist
+│   └── payload/
+│       └── etc/
+│           └── puppet_role          # Contains "gecko_t_osx_1400_r8"
+├── scripts/
+│   └── sign.sh                      # Interactive signing tool
+├── .gitignore
+└── README.md
+```
+
+## 🚀 Building a Package
+
+1. Make sure you have munkipkg installed:
+
+   ```bash
+   brew install munkipkg
+   ```
+
+2. Build the unsigned package:
+
+   ```bash
+   munkipkg p_role_gecko_t_osx_1400_r8
+   ```
+
+   This creates:
+   ```
+   p_role_gecko_t_osx_1400_r8/build/p_role_gecko_t_osx_1400_r8-1.0.pkg
+   ```
+
+## 🔐 Signing the Package
+
+Run the interactive signing script:
+
+```bash
+./scripts/sign.sh p_role_gecko_t_osx_1400_r8/build/p_role_gecko_t_osx_1400_r8-1.0.pkg
+```
+
+- If you have multiple Developer ID Installer certs, you'll be prompted to pick one.
+- The script signs and verifies the package.
+- Output:
+  ```
+  p_role_gecko_t_osx_1400_r8/build/p_role_gecko_t_osx_1400_r8-1.0-signed.pkg
+  ```
+
+> ⚠️ macOS may report "Unnotarized Developer ID" when verifying locally. This is expected for MDM use — notarization is not required for trusted `.pkg` delivery via MDM.
+
+## ☁️ Hosting & Deployment
+
+Upload the signed `.pkg` to a public or pre-signed URL (e.g., S3 or GitHub Releases), and provide that URL to your MDM system’s custom software configuration.
+
+---
+
+## ✏️ Creating New Blueprints
+
+To create a new package blueprint:
+
+```bash
+munkipkg --create my-new-pkg
+```
+
+Then populate the `payload/` folder with your desired files.
+
+---
+
+## 🧼 .gitignore
+
+We recommend ignoring the `build/` and signed `.pkg` files:
+
+```
+**/build/
+*.pkg
+```
+
+---
+
+## 🔧 Requirements
+
+- macOS with Xcode command line tools
+- `munkipkg` installed
+- A Developer ID Installer certificate in your keychain
+

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/.gitignore
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# our build directory
+build/

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/build-info.plist
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/build-info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>distribution_style</key>
+	<false/>
+	<key>identifier</key>
+	<string>com.github.munki.pkg.p_role_gecko_t_osx_1400_r8</string>
+	<key>install_location</key>
+	<string>/</string>
+	<key>name</key>
+	<string>p_role_gecko_t_osx_1400_r8-${version}.pkg</string>
+	<key>ownership</key>
+	<string>recommended</string>
+	<key>postinstall_action</key>
+	<string>none</string>
+	<key>preserve_xattr</key>
+	<false/>
+	<key>suppress_bundle_relocation</key>
+	<true/>
+	<key>version</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/payload/etc/puppet_role
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8/payload/etc/puppet_role
@@ -1,0 +1,1 @@
+gecko_t_osx_1400_r8

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/.gitignore
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# our build directory
+build/

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/build-info.plist
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/build-info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>distribution_style</key>
+	<false/>
+	<key>identifier</key>
+	<string>com.github.munki.pkg.p_role_gecko_t_osx_1400_r8_staging</string>
+	<key>install_location</key>
+	<string>/</string>
+	<key>name</key>
+	<string>p_role_gecko_t_osx_1400_r8_staging-${version}.pkg</string>
+	<key>ownership</key>
+	<string>recommended</string>
+	<key>postinstall_action</key>
+	<string>none</string>
+	<key>preserve_xattr</key>
+	<false/>
+	<key>suppress_bundle_relocation</key>
+	<true/>
+	<key>version</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/payload/etc/puppet_role
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1400_r8_staging/payload/etc/puppet_role
@@ -1,0 +1,1 @@
+gecko_t_osx_1400_r8_staging

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/.gitignore
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# our build directory
+build/

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/build-info.plist
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/build-info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>distribution_style</key>
+	<false/>
+	<key>identifier</key>
+	<string>com.github.munki.pkg.p_role_gecko_t_osx_1500_m4</string>
+	<key>install_location</key>
+	<string>/</string>
+	<key>name</key>
+	<string>p_role_gecko_t_osx_1500_m4-${version}.pkg</string>
+	<key>ownership</key>
+	<string>recommended</string>
+	<key>postinstall_action</key>
+	<string>none</string>
+	<key>preserve_xattr</key>
+	<false/>
+	<key>suppress_bundle_relocation</key>
+	<true/>
+	<key>version</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/payload/etc/puppet_role
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4/payload/etc/puppet_role
@@ -1,0 +1,1 @@
+gecko_t_osx_1500_m4

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/.gitignore
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# our build directory
+build/

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/build-info.plist
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/build-info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>distribution_style</key>
+	<false/>
+	<key>identifier</key>
+	<string>com.github.munki.pkg.p_role_gecko_t_osx_1500_m4_staging</string>
+	<key>install_location</key>
+	<string>/</string>
+	<key>name</key>
+	<string>p_role_gecko_t_osx_1500_m4_staging-${version}.pkg</string>
+	<key>ownership</key>
+	<string>recommended</string>
+	<key>postinstall_action</key>
+	<string>none</string>
+	<key>preserve_xattr</key>
+	<false/>
+	<key>suppress_bundle_relocation</key>
+	<true/>
+	<key>version</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/payload/etc/puppet_role
+++ b/osx_pkg_blueprints/p_role_gecko_t_osx_1500_m4_staging/payload/etc/puppet_role
@@ -1,0 +1,1 @@
+gecko_t_osx_1500_m4_staging

--- a/osx_pkg_blueprints/scripts/sign.sh
+++ b/osx_pkg_blueprints/scripts/sign.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Check pkg input
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 /path/to/unsigned.pkg"
+  exit 1
+fi
+
+PKG_INPUT="$1"
+if [[ ! -f "$PKG_INPUT" ]]; then
+  echo "❌ Error: File not found: $PKG_INPUT"
+  exit 1
+fi
+
+# Build list of Developer ID Installer certs
+CERT_LIST=$(security find-identity -p basic -v | grep "Developer ID Installer")
+if [[ -z "$CERT_LIST" ]]; then
+  echo "❌ No Developer ID Installer certificates found in keychain."
+  exit 1
+fi
+
+# Save certs to a temporary file
+TMP_CERTS=$(mktemp)
+INDEX=1
+echo "$CERT_LIST" | while read -r line; do
+  CERT_NAME=$(echo "$line" | sed -E 's/^ *[0-9]+\) [A-F0-9]+ "(.*)"/\1/')
+  echo "$CERT_NAME" >> "$TMP_CERTS"
+  echo "  $INDEX) $CERT_NAME"
+  INDEX=$((INDEX + 1))
+done
+
+echo ""
+read -r -p "Select a certificate number: " CHOICE
+
+# Validate and retrieve the cert
+SELECTED_CERT=$(sed -n "${CHOICE}p" "$TMP_CERTS")
+rm "$TMP_CERTS"
+
+if [[ -z "$SELECTED_CERT" ]]; then
+  echo "❌ Invalid selection."
+  exit 1
+fi
+
+# Sign the package
+PKG_DIR=$(dirname "$PKG_INPUT")
+PKG_BASENAME=$(basename "$PKG_INPUT" .pkg)
+PKG_SIGNED="${PKG_DIR}/${PKG_BASENAME}-signed.pkg"
+
+echo "📦 Signing package with:"
+echo "    $SELECTED_CERT"
+productsign --sign "$SELECTED_CERT" "$PKG_INPUT" "$PKG_SIGNED"
+
+# Verify
+echo "🔍 Verifying signed package..."
+spctl -a -vv -t install "$PKG_SIGNED"
+
+echo "✅ Signed package saved to:"
+echo "    $PKG_SIGNED"


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RELOPS-591

We’re beginning the process of improving macOS provisioning by introducing `/etc/puppet_role` as a way to bootstrap Puppet configuration automatically.

Currently, mac deployments rely exclusively on Puppet via Bolt for post-provision configuration. By landing a simple, signed `.pkg` that writes the appropriate role to `/etc/puppet_role`, we can enable Macs to auto-puppetize on first boot or MDM enrollment.

These .pkg files will be built using [munkipkg](https://github.com/munki/munki-pkg), signed with our Developer ID Installer certificate, and uploaded to MDM for distribution as part of the initial software payload.