### PR TITLE
RELOPS-1823: import Splunk Logging app and add service principal

### DIFF
--- a/terraform/azure_ad/sp_splunk_logging.tf
+++ b/terraform/azure_ad/sp_splunk_logging.tf
@@ -1,6 +1,56 @@
-# Service principal for the third-party multitenant "Splunk Logging" app.
-# Required by Microsoft's March 2026 retirement of service-principal-less authentication.
+# "Splunk Logging" app registration — Mozilla-owned, created manually in 2023.
+# Brought under terraform to create its missing service principal; required by
+# Microsoft's March 2026 retirement of service-principal-less authentication.
+resource "azuread_application" "splunk_logging" {
+  display_name     = "Splunk Logging"
+  sign_in_audience = "AzureADMyOrg"
+
+  owners = [
+    data.azuread_user.jmoss.object_id,
+    "4e48c4fe-303d-4d1d-bd6f-76f39f7b1c08", # mcornmesser@mozilla.com
+  ]
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "b0afded3-3588-46d8-8b3d-9842eff778da" # AuditLog.Read.All (application)
+      type = "Role"
+    }
+    resource_access {
+      id   = "df021288-bdef-4463-88db-98f22de89214" # User.Read.All (application)
+      type = "Role"
+    }
+    resource_access {
+      id   = "38d9df27-64da-44fd-b7c5-a6fbac20248f" # Policy.Read.All (application)
+      type = "Role"
+    }
+    resource_access {
+      id   = "381f742f-e1f8-4309-b4ab-e3d91ae4c5c1" # Directory.Read.All (application)
+      type = "Role"
+    }
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # AuditLog.Read.All (delegated)
+      type = "Scope"
+    }
+    resource_access {
+      id   = "e4c9e354-4dc5-45b8-9e7c-e1393b0b1a20" # Directory.AccessAsUser.All (delegated)
+      type = "Scope"
+    }
+    resource_access {
+      id   = "57b030f1-8c35-469c-b0d9-e4a077debe70" # User.Read.All (delegated)
+      type = "Scope"
+    }
+  }
+}
+
 resource "azuread_service_principal" "splunk_logging" {
-  client_id    = "31b68eb1-dd36-4317-a95c-9d0e42b18017"
+  client_id    = azuread_application.splunk_logging.client_id
   use_existing = true
+}
+
+# Remove after first successful apply; retained as a record of the import.
+import {
+  to = azuread_application.splunk_logging
+  id = "/applications/443480b6-0203-45b5-a128-c61633a68e05"
 }

--- a/terraform/azure_ad/sp_splunk_logging.tf
+++ b/terraform/azure_ad/sp_splunk_logging.tf
@@ -5,10 +5,7 @@ resource "azuread_application" "splunk_logging" {
   display_name     = "Splunk Logging"
   sign_in_audience = "AzureADMyOrg"
 
-  owners = [
-    data.azuread_user.jmoss.object_id,
-    "4e48c4fe-303d-4d1d-bd6f-76f39f7b1c08", # mcornmesser@mozilla.com
-  ]
+  owners = data.azuread_group.relops.members
 
   required_resource_access {
     resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph

--- a/terraform/azure_ad/sp_splunk_logging.tf
+++ b/terraform/azure_ad/sp_splunk_logging.tf
@@ -1,0 +1,6 @@
+# Service principal for the third-party multitenant "Splunk Logging" app.
+# Required by Microsoft's March 2026 retirement of service-principal-less authentication.
+resource "azuread_service_principal" "splunk_logging" {
+  client_id    = "31b68eb1-dd36-4317-a95c-9d0e42b18017"
+  use_existing = true
+}


### PR DESCRIPTION
## Summary

- Microsoft is retiring service-principal-less authentication on 2026-03-31. Our tenant received an email flagging the app **Splunk Logging** (`31b68eb1-dd36-4317-a95c-9d0e42b18017`) for acquiring ARM tokens without a service principal — it will be blocked after that date.
- On inspection, `Splunk Logging` is **Mozilla-owned** (`signInAudience: AzureADMyOrg`, created manually 2023-02-01), not a third-party multitenant app. Object ID `443480b6-0203-45b5-a128-c61633a68e05`. Owners: jmoss, mcornmesser.
- Adds `terraform/azure_ad/sp_splunk_logging.tf` with:
  - `azuread_application.splunk_logging` — declared to match current state (owners + Microsoft Graph permissions), brought in via a Terraform 1.5+ `import` block on object ID `/applications/443480b6-...`.
  - `azuread_service_principal.splunk_logging` — new resource; this is the missing enterprise app that resolves the Microsoft March 2026 deadline.
- Existing manual password credentials on the app are not touched (managed separately in the portal; outside the `azuread_application` resource in provider v3).
- Ref: https://learn.microsoft.com/entra/identity-platform/retire-service-principal-less-authentication

## Test plan

- [ ] `terraform plan` in `terraform/azure_ad/`:
  - Import shows `azuread_application.splunk_logging` being adopted with **no changes** (or only trivial ones).
  - One resource to create: `azuread_service_principal.splunk_logging`.
- [ ] `terraform apply` succeeds.
- [ ] Entra admin center → Enterprise applications: `Splunk Logging` now appears with a real object ID.
- [ ] Entra sign-in logs → Service principal sign-ins filtered on app ID `31b68eb1-...`: subsequent sign-ins show the new SP object ID instead of `00000000-0000-0000-0000-000000000000`.
- [ ] After first successful apply, delete the `import { ... }` block (it's idempotent but no longer needed).