### PR TITLE
RELOPS-2331: add CrowdStrike NGSIEM event hub log forwarding

### DIFF
--- a/terraform/azure_ad/rbac.tf
+++ b/terraform/azure_ad/rbac.tf
@@ -61,11 +61,35 @@ resource "azurerm_role_assignment" "infrasec_reader" {
   principal_id         = data.azuread_group.infrasec.object_id
 }
 
+# Reader on the tenant root management group so operators running terraform in
+# azure_infrasec can resolve the "azurerm_management_group.tenant_root" data
+# source (used to enumerate subscriptions for CrowdStrike log forwarding).
+resource "azurerm_role_assignment" "infrasec_tenant_root_mg_reader" {
+  scope                = "/providers/Microsoft.Management/managementGroups/c0dc8bb0-b616-427e-8217-9513964a145b"
+  role_definition_name = "Reader"
+  principal_id         = data.azuread_group.infrasec.object_id
+}
+
+resource "azurerm_role_assignment" "releng_tenant_root_mg_reader" {
+  scope                = "/providers/Microsoft.Management/managementGroups/c0dc8bb0-b616-427e-8217-9513964a145b"
+  role_definition_name = "Reader"
+  principal_id         = data.azuread_group.releng.object_id
+}
+
 resource "azurerm_role_assignment" "splunkeventhub" {
   for_each             = toset(var.azure_subscriptions)
   scope                = each.value
   role_definition_name = "Azure Event Hubs Data Receiver"
   principal_id         = azuread_service_principal.splunkeventhub.object_id
+}
+
+# Scoped to the CrowdStrike Event Hub Namespace only (least-privilege per the
+# Falcon NGSIEM connector guide). The namespace is managed in the
+# azure_infrasec workspace; this references it by constructed resource ID.
+resource "azurerm_role_assignment" "crowdstrikeeventhub" {
+  scope                = "/subscriptions/${var.infra_sec_subscription_id}/resourceGroups/rg-crowdstrike-eventhub/providers/Microsoft.EventHub/namespaces/mozcrowdstrikeeventhub"
+  role_definition_name = "Azure Event Hubs Data Receiver"
+  principal_id         = azuread_service_principal.crowdstrikeeventhub.object_id
 }
 
 variable "azure_subscriptions" {

--- a/terraform/azure_ad/sp_crowdstrike.tf
+++ b/terraform/azure_ad/sp_crowdstrike.tf
@@ -1,0 +1,37 @@
+# Entra ID application used by CrowdStrike Falcon NGSIEM to consume events
+# from the mozcrowdstrikeeventhub Event Hub Namespace (terraform/azure_infrasec).
+#
+# The client secret is managed in the Azure portal, not in Terraform.
+# After the application is created by this config, go to
+# Entra ID > App registrations > sp-infosec-crowdstrike-eventhub >
+# Certificates & secrets, create a client secret, and hand it to SecOps along
+# with the client ID and tenant ID.
+
+resource "azuread_application" "crowdstrikeeventhub" {
+  display_name = "sp-infosec-crowdstrike-eventhub"
+  owners       = [data.azuread_user.jmoss.object_id]
+
+  web {
+    redirect_uris = []
+
+    implicit_grant {
+      access_token_issuance_enabled = false
+      id_token_issuance_enabled     = true
+    }
+  }
+}
+
+resource "azuread_service_principal" "crowdstrikeeventhub" {
+  client_id                    = azuread_application.crowdstrikeeventhub.client_id
+  app_role_assignment_required = false
+}
+
+output "crowdstrike_eventhub_client_id" {
+  description = "Application (client) ID for the Falcon NGSIEM data connector."
+  value       = azuread_application.crowdstrikeeventhub.client_id
+}
+
+output "crowdstrike_eventhub_tenant_id" {
+  description = "Directory (tenant) ID for the Falcon NGSIEM data connector."
+  value       = data.azuread_client_config.current.tenant_id
+}

--- a/terraform/azure_infrasec/crowdstrike.tf
+++ b/terraform/azure_infrasec/crowdstrike.tf
@@ -1,0 +1,148 @@
+# CrowdStrike Falcon Next-Gen SIEM log ingestion via Azure Event Hubs.
+# Subscription enumeration is driven off the tenant root management group so
+# new subscriptions onboard automatically on the next apply.
+#
+# The Entra ID application that consumes these hubs, and its client secret,
+# are managed out-of-band (client secret is created in the Azure portal and
+# handed to SecOps directly - see RELOPS-2331).
+
+data "azurerm_management_group" "tenant_root" {
+  name = local.mozilla_tenant_id
+}
+
+data "azurerm_subscription" "tenant_subscriptions" {
+  for_each        = toset(data.azurerm_management_group.tenant_root.subscription_ids)
+  subscription_id = each.value
+}
+
+locals {
+  crowdstrike_excluded_subscription_display_names = [
+    "Azure subscription 1",
+  ]
+
+  crowdstrike_forwarding_subscriptions = {
+    for s in data.azurerm_subscription.tenant_subscriptions :
+    s.subscription_id => s.id
+    if !contains(local.crowdstrike_excluded_subscription_display_names, s.display_name)
+  }
+
+  crowdstrike_common_tags = {
+    terraform       = "true"
+    project_name    = "azure_infrasec"
+    owner_email     = "infrastructuresecurity@mozilla.com"
+    source_repo_url = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
+  }
+}
+
+resource "azurerm_resource_group" "crowdstrikeeventhub" {
+  name     = "rg-crowdstrike-eventhub"
+  location = "East US 2"
+  tags     = local.crowdstrike_common_tags
+}
+
+resource "azurerm_eventhub_namespace" "crowdstrike" {
+  capacity                 = 4
+  name                     = "mozcrowdstrikeeventhub"
+  location                 = azurerm_resource_group.crowdstrikeeventhub.location
+  resource_group_name      = azurerm_resource_group.crowdstrikeeventhub.name
+  sku                      = "Standard"
+  maximum_throughput_units = 4
+  auto_inflate_enabled     = true
+  minimum_tls_version      = "1.2"
+  tags                     = local.crowdstrike_common_tags
+}
+
+resource "azurerm_eventhub" "crowdstrike_entralogs" {
+  name                = "entralogs"
+  namespace_name      = azurerm_eventhub_namespace.crowdstrike.name
+  resource_group_name = azurerm_resource_group.crowdstrikeeventhub.name
+  partition_count     = 4
+  message_retention   = 7
+}
+
+resource "azurerm_eventhub" "crowdstrike_activitylogs" {
+  name                = "activitylogs"
+  namespace_name      = azurerm_eventhub_namespace.crowdstrike.name
+  resource_group_name = azurerm_resource_group.crowdstrikeeventhub.name
+  partition_count     = 4
+  message_retention   = 7
+}
+
+# Per CrowdStrike: each NGSIEM connector requires a dedicated consumer group
+# that is not shared with other applications.
+resource "azurerm_eventhub_consumer_group" "crowdstrike_entralogs_ngsiem" {
+  name                = "ngsiem-entra-logs"
+  namespace_name      = azurerm_eventhub_namespace.crowdstrike.name
+  eventhub_name       = azurerm_eventhub.crowdstrike_entralogs.name
+  resource_group_name = azurerm_resource_group.crowdstrikeeventhub.name
+}
+
+resource "azurerm_eventhub_consumer_group" "crowdstrike_activitylogs_ngsiem" {
+  name                = "ngsiem-activity-logs"
+  namespace_name      = azurerm_eventhub_namespace.crowdstrike.name
+  eventhub_name       = azurerm_eventhub.crowdstrike_activitylogs.name
+  resource_group_name = azurerm_resource_group.crowdstrikeeventhub.name
+}
+
+resource "azurerm_monitor_diagnostic_setting" "crowdstrikeeventhub" {
+  for_each                       = local.crowdstrike_forwarding_subscriptions
+  name                           = "crowdstrike-eventhub"
+  target_resource_id             = each.value
+  eventhub_name                  = azurerm_eventhub.crowdstrike_activitylogs.name
+  eventhub_authorization_rule_id = "/subscriptions/${local.infra_sec_subscription}/resourceGroups/${azurerm_resource_group.crowdstrikeeventhub.name}/providers/Microsoft.EventHub/namespaces/${azurerm_eventhub_namespace.crowdstrike.name}/authorizationRules/RootManageSharedAccessKey"
+
+  enabled_log {
+    category = "Administrative"
+  }
+  enabled_log {
+    category = "Security"
+  }
+  enabled_log {
+    category = "Alert"
+  }
+  enabled_log {
+    category = "Policy"
+  }
+}
+
+resource "azurerm_monitor_aad_diagnostic_setting" "crowdstrike" {
+  name                           = "crowdstrike-eventhub"
+  eventhub_name                  = azurerm_eventhub.crowdstrike_entralogs.name
+  eventhub_authorization_rule_id = "/subscriptions/${local.infra_sec_subscription}/resourceGroups/${azurerm_resource_group.crowdstrikeeventhub.name}/providers/Microsoft.EventHub/namespaces/${azurerm_eventhub_namespace.crowdstrike.name}/authorizationRules/RootManageSharedAccessKey"
+
+  enabled_log { category = "SignInLogs" }
+  enabled_log { category = "AuditLogs" }
+  enabled_log { category = "NonInteractiveUserSignInLogs" }
+  enabled_log { category = "ServicePrincipalSignInLogs" }
+  enabled_log { category = "ManagedIdentitySignInLogs" }
+  enabled_log { category = "ProvisioningLogs" }
+  enabled_log { category = "ADFSSignInLogs" }
+  enabled_log { category = "RiskyUsers" }
+  enabled_log { category = "UserRiskEvents" }
+  enabled_log { category = "NetworkAccessTrafficLogs" }
+  enabled_log { category = "ServicePrincipalRiskEvents" }
+  enabled_log { category = "EnrichedOffice365AuditLogs" }
+  enabled_log { category = "MicrosoftGraphActivityLogs" }
+  enabled_log { category = "RemoteNetworkHealthLogs" }
+  enabled_log { category = "RiskyServicePrincipals" }
+}
+
+output "crowdstrike_eventhub_namespace" {
+  description = "Event Hub Namespace name for the Falcon NGSIEM data connector."
+  value       = azurerm_eventhub_namespace.crowdstrike.name
+}
+
+output "crowdstrike_eventhub_activity_logs" {
+  description = "Event Hub name carrying subscription activity logs."
+  value       = azurerm_eventhub.crowdstrike_activitylogs.name
+}
+
+output "crowdstrike_eventhub_entra_logs" {
+  description = "Event Hub name carrying Entra ID tenant logs."
+  value       = azurerm_eventhub.crowdstrike_entralogs.name
+}
+
+output "crowdstrike_forwarding_subscriptions" {
+  description = "Subscriptions currently forwarding activity logs to CrowdStrike."
+  value       = keys(local.crowdstrike_forwarding_subscriptions)
+}


### PR DESCRIPTION
## Summary

Stream Azure activity logs and Entra ID tenant logs to CrowdStrike Falcon Next-Gen SIEM via a dedicated Event Hub Namespace in the InfraSec subscription. Splunk forwarding is unchanged and continues to receive the same log categories in parallel.

Jira: [RELOPS-2331](https://mozilla-hub.atlassian.net/browse/RELOPS-2331)

## Changes

- `terraform/azure_infrasec/crowdstrike.tf` (new): resource group `rg-crowdstrike-eventhub`, Event Hub Namespace `mozcrowdstrikeeventhub` (Standard, TLS 1.2, auto-inflate), `entralogs` and `activitylogs` hubs (7-day retention), NGSIEM-dedicated consumer groups, subscription-scope `azurerm_monitor_diagnostic_setting`, and tenant-scope `azurerm_monitor_aad_diagnostic_setting`.
- `terraform/azure_ad/sp_crowdstrike.tf` (new): Entra application and service principal `sp-infosec-crowdstrike-eventhub`. Client secret is managed in the Azure portal, not Terraform.
- `terraform/azure_ad/rbac.tf`: `Azure Event Hubs Data Receiver` on the CrowdStrike namespace for the new SP, plus `Reader` on the tenant root management group for the InfraSec and Releng groups so the `azurerm_management_group` data source resolves.

## Subscription enumeration

Diagnostic settings iterate over subscriptions discovered from the tenant root management group (`c0dc8bb0-...`), filtered to exclude `Azure subscription 1`. New subscriptions added to the tenant onboard automatically on the next apply.

## Apply order

1. `cd terraform/azure_ad && terraform plan && terraform apply` — creates the role assignments for MG reader and the Entra app/SP.
2. `cd terraform/azure_infrasec && terraform plan && terraform apply` — creates the namespace, hubs, consumer groups, and diagnostic settings.
3. Azure portal: Entra ID → App registrations → `sp-infosec-crowdstrike-eventhub` → Certificates & secrets → create a client secret. Hand the value to SecOps along with the `crowdstrike_eventhub_client_id` and `crowdstrike_eventhub_tenant_id` outputs.
4. SecOps configures the Falcon data connector with the above plus namespace / hub / consumer group names (from the `azure_infrasec` outputs).

## Test plan

- [ ] `terraform plan` in `azure_ad` shows only the three new role assignments and the new app/SP
- [ ] `terraform plan` in `azure_infrasec` shows the new resource group, namespace, hubs, consumer groups, and diagnostic settings; verify the `crowdstrike_forwarding_subscriptions` output excludes `Azure subscription 1`
- [ ] After apply, confirm activity logs appear on the `activitylogs` hub and Entra logs on the `entralogs` hub via the Azure portal Messages chart (PDF Step 7)
- [ ] SecOps validates ingestion in Falcon (PDF Step 9)