### PR TITLE
Add canada-east and southeast-asia to gecko-t location_map

### DIFF
--- a/terraform/azure_fxci/gecko-t/main.tf
+++ b/terraform/azure_fxci/gecko-t/main.tf
@@ -1,6 +1,7 @@
 locals {
   location_map = {
     "Canada Central"   = "canada-central"
+    "Canada East"      = "canada-east"
     "Central India"    = "central-india"
     "Central US"       = "central-us"
     "East US"          = "east-us"
@@ -8,6 +9,7 @@ locals {
     "North Central US" = "north-central-us"
     "North Europe"     = "north-europe"
     "South India"      = "south-india"
+    "Southeast Asia"   = "southeast-asia"
     "UK South"         = "uk-south"
     "West US"          = "west-us"
     "West US 2"        = "west-us-2"


### PR DESCRIPTION
Provisions the per-region infrastructure (resource group, vnet/subnet, NSG, storage account) for two new Azure regions added to \`gecko-t/win11-64-25h2\` in [mozilla-releng/fxci-config#946](https://github.com/mozilla-releng/fxci-config/pull/946):

- \`canada-east\` (Americas)
- \`southeast-asia\` (APAC — Singapore)

\`uk-south\` is the third region in fxci-config#946 but is already in the gecko-t \`location_map\`, so no change there.

## Selection rationale

Both regions sit in Azure's 0-5% bucket of the 28-day \`Standard_F8s_v2\` Spot eviction history (\`AzureResourceGraph.SpotResources\`) and are below the current pool's median Spot Windows price. uk-south is the cheapest 0-5% region in the candidate set (\$0.1081/hr, 26% under median). canada-east and southeast-asia are the geographically-paired Americas and APAC picks. See fxci-config#946 for the full cost+eviction analysis.

## What this provisions

Each entry in \`location_map\` triggers the \`workerPool_v1\` module to create:
- \`rg-<region>-gecko-t\`
- \`vn-<region>-gecko-t\` and \`sn-<region>-gecko-t\` (vnet + subnet)
- \`nsg-<region>-gecko-t\` (network security group)
- \`sa<region>-gecko-t\` (storage account)

## Plan

@jmoss will run \`terraform apply\` locally after merge.

## Out of scope

This PR only touches the \`gecko-t\` \`location_map\`. Other pools (\`comm-t\`, \`comm-1\`, \`gecko-1\`, \`gecko-2\`, \`enterprise-t\`, \`enterprise-1\`, \`nss-t\`, \`nss-1\`, \`mozilla-1\`, \`taskgraph-t\`) also have \`location_map\` blocks but are not modified here. The companion change in [mozilla-platform-ops/worker-images](https://github.com/mozilla-platform-ops/worker-images) replicates Windows images globally to canadaeast/southeastasia, so any of those pools that later want to launch in those regions can be added in a follow-up.