### PR TITLE
Add second SP3 dedicated host

### DIFF
--- a/terraform/azure_fxci/gecko-t/dedicated-host-sp3-perf.tf
+++ b/terraform/azure_fxci/gecko-t/dedicated-host-sp3-perf.tf
@@ -46,6 +46,24 @@ resource "azapi_resource" "sp3_perf_experiment_host" {
   }
 }
 
+resource "azapi_resource" "sp3_perf_experiment_host_02" {
+  type      = "Microsoft.Compute/hostGroups/hosts@2023-09-01"
+  name      = "dh-${local.sp3_perf_dedicated_host_slug}-${local.provisioner}-sp3-perf-02"
+  parent_id = azapi_resource.sp3_perf_experiment_host_group.id
+  location  = azurerm_resource_group.nongw[local.sp3_perf_dedicated_host_location].location
+  tags      = local.sp3_perf_dedicated_host_tags
+
+  body = {
+    sku = {
+      name = "NVadsA10v5_Type1"
+    }
+    properties = {
+      platformFaultDomain  = 0
+      autoReplaceOnFailure = true
+    }
+  }
+}
+
 output "sp3_perf_dedicated_host_group_id" {
   description = "Dedicated Host Group ID for the RELOPS-2375 Speedometer 3 GPU perf experiment."
   value       = azapi_resource.sp3_perf_experiment_host_group.id
@@ -54,6 +72,19 @@ output "sp3_perf_dedicated_host_group_id" {
 output "sp3_perf_dedicated_host_id" {
   description = "Dedicated Host ID for the RELOPS-2375 Speedometer 3 GPU perf experiment."
   value       = azapi_resource.sp3_perf_experiment_host.id
+}
+
+output "sp3_perf_dedicated_host_02_id" {
+  description = "Second Dedicated Host ID for the RELOPS-2375 Speedometer 3 GPU perf experiment."
+  value       = azapi_resource.sp3_perf_experiment_host_02.id
+}
+
+output "sp3_perf_dedicated_host_ids" {
+  description = "Dedicated Host IDs for the RELOPS-2375 Speedometer 3 GPU perf experiment."
+  value = [
+    azapi_resource.sp3_perf_experiment_host.id,
+    azapi_resource.sp3_perf_experiment_host_02.id,
+  ]
 }
 
 output "sp3_perf_dedicated_host_resource_group_name" {


### PR DESCRIPTION
## Summary
- Add a second NVadsA10v5_Type1 dedicated host to the existing SP3 perf experiment host group
- Add outputs for the second host and the full host ID list

## Context
Follow-up to https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/295, which added the first dedicated host for the SP3 perf experiment.

Based on https://mozilla-hub.atlassian.net/browse/RELOPS-2375 for the Bug 2039391 Windows 11 25H2 GPU Speedometer 3 dedicated-host experiment. The existing fxci-config template spec targets the host group, so adding another host in the same group should allow Azure automatic placement to use the added capacity.

## Validation
- terraform fmt terraform/azure_fxci/gecko-t/dedicated-host-sp3-perf.tf
- git diff --check -- terraform/azure_fxci/gecko-t/dedicated-host-sp3-perf.tf

Terraform plan/apply will be run separately after the StandardNVADSA10v5Family quota bump is available.