### PR TITLE
RELOPS-2427: build AWS images in relops-aws-prod

### DIFF
--- a/terraform/aws_relops-aws-prod/README.md
+++ b/terraform/aws_relops-aws-prod/README.md
@@ -1,0 +1,41 @@
+# AWS RelOps Worker Images GitHub OIDC Configuration
+
+This Terraform module configures GitHub Actions OIDC authentication in the
+`relops-aws-prod` AWS account (`961225894672`) for worker image builds.
+
+## Overview
+
+This creates the same GitHub Actions/Packer authentication resources used by
+the `aws_moz-fx-tc-community-workers` module, but in `relops-aws-prod`:
+
+- GitHub OIDC provider for `https://token.actions.githubusercontent.com`
+- `GitHubActionsRole` for GitHub Actions workflows
+- `GitHubActionsPackerPolicy` with the EC2 permissions Packer needs to build AMIs
+
+The default repository allowlist is:
+
+```hcl
+oidc_github_repositories = ["mozilla-platform-ops/worker-images", "mozilla-platform-ops/monopacker"]
+```
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+After applying, worker-images can assume:
+
+```text
+arn:aws:iam::961225894672:role/GitHubActionsRole
+```
+
+If the GitHub OIDC provider already exists in `relops-aws-prod`, import it
+before applying:
+
+```bash
+terraform import aws_iam_openid_connect_provider.github_actions arn:aws:iam::961225894672:oidc-provider/token.actions.githubusercontent.com
+```
+

--- a/terraform/aws_relops-aws-prod/github_oidc.tf
+++ b/terraform/aws_relops-aws-prod/github_oidc.tf
@@ -1,0 +1,134 @@
+# This Terraform configuration file's goal is to assign IAM roles to GitHub Actions.
+
+# Fetch GitHub's OIDC provider certificate thumbprint dynamically.
+# This is required by AWS to verify the OIDC provider's identity.
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# Create the GitHub OIDC provider.
+# Note: Only one OIDC provider per URL can exist in an AWS account.
+# If you already have a GitHub OIDC provider, import it with:
+# terraform import aws_iam_openid_connect_provider.github_actions arn:aws:iam::961225894672:oidc-provider/token.actions.githubusercontent.com
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+
+  tags = {
+    Name        = "github-actions-oidc"
+    Project     = "relops-aws-prod"
+    Environment = "production"
+  }
+}
+
+# IAM policy for Packer permissions.
+data "aws_iam_policy_document" "github_actions_packer" {
+  statement {
+    sid    = "PackerEC2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CopyImage",
+      "ec2:CreateImage",
+      "ec2:CreateKeypair",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteKeyPair",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteVolume",
+      "ec2:DeregisterImage",
+      "ec2:DescribeImageAttribute",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeRegions",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
+      "ec2:GetPasswordData",
+      "ec2:ModifyImageAttribute",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifySnapshotAttribute",
+      "ec2:RegisterImage",
+      "ec2:RunInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions_packer" {
+  name        = "GitHubActionsPackerPolicy"
+  description = "Policy for GitHub Actions to run Packer for AMI creation"
+  policy      = data.aws_iam_policy_document.github_actions_packer.json
+
+  tags = {
+    Name        = "github-actions-packer-policy"
+    Project     = "relops-aws-prod"
+    Environment = "production"
+  }
+}
+
+# IAM role that GitHub Actions will assume.
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = flatten([
+        for repo in var.oidc_github_repositories : [
+          "repo:${repo}:ref:refs/heads/main",
+          "repo:${repo}:environment:prod"
+        ]
+      ])
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "GitHubActionsRole"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+  description        = "IAM role for GitHub Actions to authenticate via OIDC"
+
+  tags = {
+    Name        = "github-actions-role"
+    Project     = "relops-aws-prod"
+    Environment = "production"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_packer" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.github_actions_packer.arn
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+

--- a/terraform/aws_relops-aws-prod/providers.tf
+++ b/terraform/aws_relops-aws-prod/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region              = var.aws_region
+  profile             = "AdministratorAccess-961225894672"
+  allowed_account_ids = ["961225894672"]
+}
+

--- a/terraform/aws_relops-aws-prod/terraform.tf
+++ b/terraform/aws_relops-aws-prod/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "relops-tf-states"
+    key          = "aws_relops-aws-prod.tfstate"
+    use_lockfile = true
+    region       = "us-west-2"
+    profile      = "AdministratorAccess-961225894672"
+  }
+}

--- a/terraform/aws_relops-aws-prod/variables.tf
+++ b/terraform/aws_relops-aws-prod/variables.tf
@@ -1,0 +1,12 @@
+variable "oidc_github_repositories" {
+  type        = set(string)
+  description = "List of GitHub repositories (format: owner/repo) allowed to assume the IAM role via OIDC"
+  default     = ["mozilla-platform-ops/worker-images", "mozilla-platform-ops/monopacker"]
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for resources"
+  default     = "us-west-2"
+}
+


### PR DESCRIPTION
## Summary
- add a relops-aws-prod Terraform root for worker-images GitHub OIDC auth
- create the same GitHubActionsRole/GitHubActionsPackerPolicy pattern used by the community worker account
- allow mozilla-platform-ops/worker-images and mozilla-platform-ops/monopacker to assume the role from main or the prod environment

## Outputs
After apply, worker-images can use:

```text
github_actions_role_arn = "arn:aws:iam::961225894672:role/GitHubActionsRole"
github_oidc_provider_arn = "arn:aws:iam::961225894672:oidc-provider/token.actions.githubusercontent.com"
```

## Validation
- terraform -chdir=terraform/aws_relops-aws-prod init -backend=false
- terraform -chdir=terraform/aws_relops-aws-prod validate
- git diff --check