### PR TITLE
RELOPS-2427: add Taskcluster AWS and proj-fuzzing Azure infrastructure

### DIFF
--- a/terraform/aws_taskcluster/README.md
+++ b/terraform/aws_taskcluster/README.md
@@ -1,0 +1,54 @@
+# AWS Taskcluster Worker Images and Worker Manager
+
+This Terraform module configures the AWS account used by Taskcluster for
+FirefoxCI AWS worker image builds and worker provisioning.
+
+## Overview
+
+This module creates:
+
+- GitHub OIDC provider for GitHub Actions
+- IAM role and policy for worker image Packer builds
+- Existing IAM user and policy for FirefoxCI Taskcluster worker-manager AWS
+  provisioning
+
+The FirefoxCI worker-manager IAM principal already exists in this account as
+`firefox-ci-taskcluster-worker-manager`. Import it before applying this module.
+The imported user and policy are documented here without changing their access
+key, policy document, or tags.
+
+## Configuration
+
+Edit `terraform.tfvars` for the target account, profile, allowed GitHub
+repositories, and worker-manager IAM names if needed.
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+The S3 backend configuration intentionally does not set a profile. Pass the
+backend profile during init if your default AWS profile cannot read the shared
+state bucket:
+
+```bash
+terraform init -backend-config=profile=<state-bucket-profile>
+```
+
+If the GitHub OIDC provider already exists, import it before applying:
+
+```bash
+terraform import aws_iam_openid_connect_provider.github_actions "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+```
+
+If the FirefoxCI worker-manager user and policy already exist, import them
+before applying:
+
+```bash
+terraform import aws_iam_user.taskcluster_worker_manager firefox-ci-taskcluster-worker-manager
+terraform import aws_iam_policy.taskcluster_worker_manager arn:aws:iam::<account-id>:policy/taskcluster-worker-manager
+terraform import aws_iam_user_policy_attachment.taskcluster_worker_manager firefox-ci-taskcluster-worker-manager/arn:aws:iam::<account-id>:policy/taskcluster-worker-manager
+```

--- a/terraform/aws_taskcluster/github_oidc.tf
+++ b/terraform/aws_taskcluster/github_oidc.tf
@@ -1,0 +1,96 @@
+# GitHub Actions OIDC authentication for worker image builds.
+data "tls_certificate" "github" {
+  url = var.github_oidc_url
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = var.github_oidc_url
+  client_id_list  = [var.github_oidc_audience]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}
+
+data "aws_iam_policy_document" "github_actions_packer" {
+  statement {
+    sid    = "PackerEC2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CopyImage",
+      "ec2:CreateImage",
+      "ec2:CreateKeypair",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteKeyPair",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteVolume",
+      "ec2:DeregisterImage",
+      "ec2:DescribeImageAttribute",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeRegions",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
+      "ec2:GetPasswordData",
+      "ec2:ModifyImageAttribute",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifySnapshotAttribute",
+      "ec2:RegisterImage",
+      "ec2:RunInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions_packer" {
+  name        = var.github_actions_packer_policy_name
+  description = "Policy for GitHub Actions to run Packer for AMI creation"
+  policy      = data.aws_iam_policy_document.github_actions_packer.json
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = [var.github_oidc_audience]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = flatten([
+        for repo in var.oidc_github_repositories : [
+          "repo:${repo}:ref:refs/heads/main",
+          "repo:${repo}:environment:prod"
+        ]
+      ])
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = var.github_actions_role_name
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+  description        = "IAM role for GitHub Actions to authenticate via OIDC"
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_packer" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.github_actions_packer.arn
+}

--- a/terraform/aws_taskcluster/locals.tf
+++ b/terraform/aws_taskcluster/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}

--- a/terraform/aws_taskcluster/providers.tf
+++ b/terraform/aws_taskcluster/providers.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region              = var.aws_region
+  profile             = var.aws_profile
+  allowed_account_ids = [var.aws_account_id]
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+provider "aws" {
+  alias               = "us_east_1"
+  region              = "us-east-1"
+  profile             = var.aws_profile
+  allowed_account_ids = [var.aws_account_id]
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+provider "aws" {
+  alias               = "us_west_1"
+  region              = "us-west-1"
+  profile             = var.aws_profile
+  allowed_account_ids = [var.aws_account_id]
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+provider "aws" {
+  alias               = "us_west_2"
+  region              = "us-west-2"
+  profile             = var.aws_profile
+  allowed_account_ids = [var.aws_account_id]
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/terraform/aws_taskcluster/taskcluster_worker_manager.tf
+++ b/terraform/aws_taskcluster/taskcluster_worker_manager.tf
@@ -1,0 +1,50 @@
+# Existing IAM principal used by FirefoxCI Taskcluster worker-manager to
+# provision AWS workers. Access keys are intentionally managed out of band so
+# long-lived secrets are not stored in Terraform state. Tags are ignored because
+# this resource predates this Terraform module.
+resource "aws_iam_user" "taskcluster_worker_manager" {
+  name          = var.taskcluster_worker_manager_user_name
+  force_destroy = false
+
+  lifecycle {
+    ignore_changes = [
+      force_destroy,
+      tags,
+      tags_all,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "taskcluster_worker_manager" {
+  statement {
+    sid    = "VisualEditor0"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions",
+      "ec2:DescribeInstanceStatus",
+      "ec2:CreateTags",
+      "ec2:RunInstances",
+      "ec2:TerminateInstances",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "taskcluster_worker_manager" {
+  name        = var.taskcluster_worker_manager_policy_name
+  description = "Per the TC docs"
+  policy      = data.aws_iam_policy_document.taskcluster_worker_manager.json
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+      tags_all,
+    ]
+  }
+}
+
+resource "aws_iam_user_policy_attachment" "taskcluster_worker_manager" {
+  user       = aws_iam_user.taskcluster_worker_manager.name
+  policy_arn = aws_iam_policy.taskcluster_worker_manager.arn
+}

--- a/terraform/aws_taskcluster/terraform.tf
+++ b/terraform/aws_taskcluster/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+    bucket       = "relops-tf-states"
+    key          = "aws_taskcluster.tfstate"
+    use_lockfile = true
+    region       = "us-west-2"
+  }
+
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/aws_taskcluster/variables.tf
+++ b/terraform/aws_taskcluster/variables.tf
@@ -1,0 +1,68 @@
+variable "aws_account_id" {
+  type        = string
+  description = "AWS account ID for the Taskcluster worker account"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "AWS CLI profile for the Taskcluster worker account"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "Default AWS region for global IAM resources"
+  default     = "us-west-2"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment tag value"
+  default     = "production"
+}
+
+variable "github_actions_packer_policy_name" {
+  type        = string
+  description = "IAM policy name for GitHub Actions Packer builds"
+  default     = "GitHubActionsPackerPolicy"
+}
+
+variable "github_actions_role_name" {
+  type        = string
+  description = "IAM role name for GitHub Actions OIDC"
+  default     = "GitHubActionsRole"
+}
+
+variable "github_oidc_audience" {
+  type        = string
+  description = "GitHub OIDC audience accepted by AWS STS"
+  default     = "sts.amazonaws.com"
+}
+
+variable "github_oidc_url" {
+  type        = string
+  description = "GitHub Actions OIDC issuer URL"
+  default     = "https://token.actions.githubusercontent.com"
+}
+
+variable "oidc_github_repositories" {
+  type        = set(string)
+  description = "List of GitHub repositories (format: owner/repo) allowed to assume the IAM role via OIDC"
+}
+
+variable "project_name" {
+  type        = string
+  description = "Project tag value"
+  default     = "aws-taskcluster"
+}
+
+variable "taskcluster_worker_manager_policy_name" {
+  type        = string
+  description = "IAM policy name for Taskcluster worker-manager"
+  default     = "taskcluster-worker-manager"
+}
+
+variable "taskcluster_worker_manager_user_name" {
+  type        = string
+  description = "IAM user name for FirefoxCI Taskcluster worker-manager"
+  default     = "firefox-ci-taskcluster-worker-manager"
+}

--- a/terraform/azure_fxci/proj-fuzzing/main.tf
+++ b/terraform/azure_fxci/proj-fuzzing/main.tf
@@ -1,0 +1,60 @@
+locals {
+  location_map = {
+    "Central US" = "central-us"
+    "East US"    = "east-us"
+    "West US 2"  = "west-us-2"
+  }
+
+  config = yamldecode(file("../config.yaml"))
+  tags = {
+    terraform       = "true"
+    source_repo_url = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
+  }
+  provisioner = "proj-fuzzing"
+
+  # Mirrors the TCeng RDP_Only NSGs used by current Windows image resources.
+  rdp_source_address_prefixes = [
+    "63.245.208.133",
+    "63.245.208.132",
+    "185.155.182.210",
+  ]
+
+  nsg_security_rules = [
+    {
+      name                       = "AllowCidrBlockRDPInbound"
+      priority                   = 100
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_ranges    = ["3389"]
+      source_address_prefixes    = local.rdp_source_address_prefixes
+      destination_address_prefix = "*"
+    }
+  ]
+}
+
+resource "azurerm_resource_group" "nongw" {
+  for_each = local.location_map
+  name     = "rg-${each.value}-${local.provisioner}"
+  location = each.key
+  tags     = local.tags
+}
+
+module "proj_fuzzing_nogw" {
+  for_each                            = local.location_map
+  source                              = "../../azure_modules/workerPool_v1"
+  location                            = each.key
+  azurerm_virtual_network_name        = "vn-${each.value}-${local.provisioner}"
+  azurerm_subnet_name                 = "sn-${each.value}-${local.provisioner}"
+  resource_group_name                 = azurerm_resource_group.nongw[each.key].name
+  azurerm_network_security_group_name = "nsg-${each.value}-${local.provisioner}"
+  azurerm_storage_account_name        = "sa${each.value}-${local.provisioner}"
+  vnet_address_space                  = local.config.defaults.vnet_address_space
+  vnet_dns_servers                    = local.config.defaults.vnet_dns_servers
+  subnet_address_prefixes             = local.config.defaults.subnet_address_prefixes
+  provisioner                         = local.provisioner
+  tags                                = local.tags
+  nsg_security_rules                  = local.nsg_security_rules
+  depends_on                          = [azurerm_resource_group.nongw]
+}

--- a/terraform/azure_fxci/proj-fuzzing/terraform.tf
+++ b/terraform/azure_fxci/proj-fuzzing/terraform.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket       = "relops-tf-states"
+    key          = "azure_fxci_proj_fuzzing.tfstate"
+    use_lockfile = true
+    region       = "us-west-2"
+  }
+}
+
+provider "aws" {
+  allowed_account_ids = ["961225894672"]
+  alias               = "us-west-2"
+  region              = "us-west-2"
+}
+
+# Configure the Azure Provider
+provider "azurerm" {
+  features {}
+
+  # FXCI Azure dev/test Subscription
+  subscription_id = "108d46d5-fe9b-4850-9a7d-8c914aa6c1f0"
+  tenant_id       = "c0dc8bb0-b616-427e-8217-9513964a145b"
+}

--- a/terraform/azure_modules/workerPool_v1/main.tf
+++ b/terraform/azure_modules/workerPool_v1/main.tf
@@ -23,15 +23,15 @@ resource "azurerm_network_security_group" "this" {
   dynamic "security_rule" {
     for_each = var.nsg_security_rules
     content {
-      name                       = each.value.name
-      priority                   = each.value.priority
-      direction                  = each.value.direction
-      access                     = each.value.access
-      protocol                   = each.value.protocol
-      source_port_range          = each.value.source_port_range
-      destination_port_ranges    = each.value.destination_port_ranges
-      source_address_prefixes    = each.value.source_address_prefixes
-      destination_address_prefix = each.value.destination_address_prefix
+      name                       = security_rule.value.name
+      priority                   = security_rule.value.priority
+      direction                  = security_rule.value.direction
+      access                     = security_rule.value.access
+      protocol                   = security_rule.value.protocol
+      source_port_range          = security_rule.value.source_port_range
+      destination_port_ranges    = security_rule.value.destination_port_ranges
+      source_address_prefixes    = security_rule.value.source_address_prefixes
+      destination_address_prefix = security_rule.value.destination_address_prefix
     }
   }
 }


### PR DESCRIPTION
## Summary

- add a minimal `aws_taskcluster` Terraform module for the temporary AWS migration path: GitHub Actions/Packer OIDC plus imported FirefoxCI worker-manager IAM documentation
- add Azure `proj-fuzzing` network resources using the names generated by fxci-config
- fix the shared Azure `workerPool_v1` NSG dynamic block so non-empty `nsg_security_rules` can plan/apply

## Related work

- mozilla-platform-ops/worker-images#802 updates the TCEng AWS workflow to build images in `692406183521`
- mozilla-releng/fxci-config#1042 consumes the fuzzing worker images and pools

## Evidence

- account `692406183521` authenticated locally via the `692406183521_AdministratorAccess` profile
- `m5d.metal` is available in the configured AWS fuzzing regions, and the account has sufficient Standard Spot/On-Demand vCPU quota
- the legacy docker-worker AMIs were copied from account `885316786408` into `692406183521`; fxci-config#1042 points at the copied AMI IDs
- the staging Ubuntu AWS AMI was copied from relops-prod account `961225894672` into `692406183521`; fxci-config#1042 points at the copied AMI ID
- no Terraform changes are needed in `aws_moz-fx-tc-community-workers` for this path
- the existing `firefox-ci-taskcluster-worker-manager` user, `taskcluster-worker-manager` policy, and policy attachment were imported into state; the Terraform plan is no-op for them and does not add EC2 actions
- the Azure `rg-*-proj-fuzzing` resource groups do not exist yet and are created here with `vn/sn/nsg-*-proj-fuzzing`

## Validation

- `terraform fmt -check terraform/azure_modules/workerPool_v1/main.tf terraform/azure_fxci/proj-fuzzing/main.tf terraform/azure_fxci/proj-fuzzing/terraform.tf terraform/aws_taskcluster`
- `terraform -chdir=terraform/aws_taskcluster validate -no-color`
- `terraform -chdir=terraform/azure_fxci/proj-fuzzing validate -no-color`
- `terraform -chdir=terraform/aws_taskcluster plan -no-color -var='aws_account_id=692406183521' -var='aws_profile=692406183521_AdministratorAccess' -var='oidc_github_repositories=["mozilla-platform-ops/worker-images","mozilla-platform-ops/monopacker"]'` reports `No changes`
- `terraform -chdir=terraform/azure_fxci/proj-fuzzing plan -no-color` reports `18 to add, 0 to change, 0 to destroy`