### PR TITLE
RELOPS-2427: add proj-fuzzing Azure GPU regions

### DIFF
--- a/terraform/azure_fxci/proj-fuzzing/main.tf
+++ b/terraform/azure_fxci/proj-fuzzing/main.tf
@@ -1,8 +1,10 @@
 locals {
   location_map = {
-    "Central US" = "central-us"
-    "East US"    = "east-us"
-    "West US 2"  = "west-us-2"
+    "Central US"       = "central-us"
+    "East US"          = "east-us"
+    "East US 2"        = "east-us-2"
+    "South Central US" = "south-central-us"
+    "West US 2"        = "west-us-2"
   }
 
   config = yamldecode(file("../config.yaml"))
@@ -10,7 +12,8 @@ locals {
     terraform       = "true"
     source_repo_url = "https://github.com/mozilla-platform-ops/relops_infra_as_code"
   }
-  provisioner = "proj-fuzzing"
+  provisioner            = "proj-fuzzing"
+  storage_account_suffix = "projfuzzing"
 
   # Mirrors the TCeng RDP_Only NSGs used by current Windows image resources.
   rdp_source_address_prefixes = [
@@ -49,7 +52,7 @@ module "proj_fuzzing_nogw" {
   azurerm_subnet_name                 = "sn-${each.value}-${local.provisioner}"
   resource_group_name                 = azurerm_resource_group.nongw[each.key].name
   azurerm_network_security_group_name = "nsg-${each.value}-${local.provisioner}"
-  azurerm_storage_account_name        = "sa${each.value}-${local.provisioner}"
+  azurerm_storage_account_name        = "sa${replace(each.value, "south-central-us", "scus")}-${local.storage_account_suffix}"
   vnet_address_space                  = local.config.defaults.vnet_address_space
   vnet_dns_servers                    = local.config.defaults.vnet_dns_servers
   subnet_address_prefixes             = local.config.defaults.subnet_address_prefixes


### PR DESCRIPTION
## Summary
- add East US 2 and South Central US to the proj-fuzzing Azure location map
- keep existing resource names for Central US, East US, and West US 2
- shorten only the South Central US storage account name to stay within Azure's 24-character limit

## Apply status
- Terraform plan before apply: 12 to add, 0 to change, 0 to destroy
- Terraform apply completed successfully: 12 added, 0 changed, 0 destroyed
- Post-apply Terraform plan reports no changes

## Notes
- This supports the fxci-config fuzzing GPU pools using the same regional coverage as community-tc-config.