### PR TITLE
RELOPS-2440 Set clauditor audience app ID URI

### DIFF
--- a/terraform/azure_ad/fuzzing.tf
+++ b/terraform/azure_ad/fuzzing.tf
@@ -64,10 +64,11 @@ resource "azuread_service_principal" "fuzzing_azure_devtest" {
 }
 
 resource "azuread_application" "clauditor" {
-  for_each     = local.clauditor_apps
-  display_name = each.value.name
-  owners       = data.azuread_group.relops.members
-  notes        = each.value.notes
+  for_each        = local.clauditor_apps
+  display_name    = each.value.name
+  identifier_uris = each.key == "audience" ? ["api://2925ef06-ce42-4a1b-bf35-70358136a900"] : []
+  owners          = data.azuread_group.relops.members
+  notes           = each.value.notes
 }
 
 resource "azuread_service_principal" "clauditor" {


### PR DESCRIPTION
## Summary
- set `sp-clauditor-audience` application ID URI to `api://2925ef06-ce42-4a1b-bf35-70358136a900`
- keep the URI managed in Terraform so GCP/Anthropic can use it as the audience

## Verification
- `terraform -chdir=terraform/azure_ad validate`
- `AWS_PROFILE=AdministratorAccess-961225894672 terraform -chdir=terraform/azure_ad plan`
- `AWS_PROFILE=AdministratorAccess-961225894672 terraform -chdir=terraform/azure_ad apply -auto-approve`
- `az ad app show --id 2925ef06-ce42-4a1b-bf35-70358136a900 --query "{displayName:displayName, appId:appId, identifierUris:identifierUris}" -o json`

Terraform apply completed with 0 added, 1 changed, 0 destroyed.