### PR TITLE
RELOPS-2440 use environment=azure to gate clauditor oidc to azure

### DIFF
--- a/terraform/azure_ad/fuzzing.tf
+++ b/terraform/azure_ad/fuzzing.tf
@@ -19,17 +19,10 @@ locals {
   clauditor_federated_credentials = {
     build_main = {
       app          = "build"
-      display_name = "github-actions-main"
-      description  = "GitHub Actions OIDC for main branch workflows in MozillaSecurity/clauditor"
+      display_name = "github-actions-azure"
+      description  = "GitHub Actions OIDC for environment=azure workflows in MozillaSecurity/clauditor"
       issuer       = "https://token.actions.githubusercontent.com"
-      subject      = "repo:MozillaSecurity/clauditor:ref:refs/heads/main"
-    }
-    build_pr = {
-      app          = "build"
-      display_name = "github-actions-pr"
-      description  = "GitHub Actions OIDC for pull_request workflows in MozillaSecurity/clauditor"
-      issuer       = "https://token.actions.githubusercontent.com"
-      subject      = "repo:MozillaSecurity/clauditor:pull_request"
+      subject      = "repo:MozillaSecurity/clauditor:environment:azure"
     }
     run_gcp = {
       app          = "run"


### PR DESCRIPTION
this account is also used in a GHA cron job, so gating on main/pr doesn't help.
```
Running Azure CLI Login.
/usr/bin/az cloud set -n azurecloud
Done setting cloud: "azurecloud"
Federated token details:
 issuer - https://token.actions.githubusercontent.com/
 subject claim - repo:MozillaSecurity/clauditor:environment:azure
 audience - api://AzureADTokenExchange
 job_workflow_ref - MozillaSecurity/clauditor/.github/workflows/azure-build.yml@refs/heads/main
Attempting Azure CLI login by using OIDC...
Error: AADSTS700213: No matching federated identity record found for presented assertion subject 'repo:MozillaSecurity/clauditor:environment:azure'. Check your federated identity credential Subject, Audience and Issuer against the presented assertion. https://learn.microsoft.com/entra/workload-id/workload-identity-federation Trace ID: 0d30836b-09e2-4919-af54-b9e0cca54200 Correlation ID: 7ed83611-df69-45f5-928f-d9dba4d419db Timestamp: 2026-06-27 04:22:34Z
```