### PR TITLE
RELOPS-2495: Manage Firefox WNS Entra identity

### DIFF
--- a/terraform/azure_ad/sp_firefox_wns.tf
+++ b/terraform/azure_ad/sp_firefox_wns.tf
@@ -1,27 +1,16 @@
 # Mozilla-owned identity for the Firefox WNS work in Bug 1803416.
 # Add a client credential only after the sender and secret store are defined.
 
-data "azuread_user" "aborondo" {
-  user_principal_name = "aborondo@mozilla.com"
-}
-
-locals {
-  firefox_wns_owners = concat(
-    data.azuread_group.relops.members,
-    [data.azuread_user.aborondo.object_id],
-  )
-}
-
 resource "azuread_application" "firefox_wns" {
   display_name     = "Firefox WNS"
   description      = "Mozilla-owned identity for Firefox Windows App SDK push notification work (RELOPS-2495, Bug 1803416)."
   sign_in_audience = "AzureADMultipleOrgs"
-  owners           = local.firefox_wns_owners
+  owners           = data.azuread_group.relops.members
 }
 
 resource "azuread_service_principal" "firefox_wns" {
   client_id = azuread_application.firefox_wns.client_id
-  owners    = local.firefox_wns_owners
+  owners    = data.azuread_group.relops.members
   tags      = concat(["name:firefox-wns"], local.sp_tags)
 }
 

--- a/terraform/azure_ad/sp_firefox_wns.tf
+++ b/terraform/azure_ad/sp_firefox_wns.tf
@@ -1,22 +1,14 @@
-# Mozilla-owned Entra identity for Firefox Windows App SDK push notification
-# work. This replaces the personal identity used by the Bug 1803416 prototype.
-#
-# WNS requires a multi-tenant application registration and a service principal.
-# The service principal object ID is the remote identifier that Firefox uses to
-# request a WNS channel. The application client ID and Mozilla tenant ID are used
-# by the sender to request an access token for https://wns.windows.com/.default.
-#
-# A client credential is not created here. Add one only after the WNS sender and
-# its approved secret store are defined. Never commit or output the credential.
+# Mozilla-owned identity for the Firefox WNS work in Bug 1803416.
+# Add a client credential only after the sender and secret store are defined.
 
 data "azuread_user" "aborondo" {
   user_principal_name = "aborondo@mozilla.com"
 }
 
 locals {
-  firefox_wns_owners = setunion(
-    toset(data.azuread_group.relops.members),
-    toset([data.azuread_user.aborondo.object_id]),
+  firefox_wns_owners = concat(
+    data.azuread_group.relops.members,
+    [data.azuread_user.aborondo.object_id],
   )
 }
 
@@ -28,10 +20,9 @@ resource "azuread_application" "firefox_wns" {
 }
 
 resource "azuread_service_principal" "firefox_wns" {
-  client_id                    = azuread_application.firefox_wns.client_id
-  app_role_assignment_required = false
-  owners                       = local.firefox_wns_owners
-  tags                         = concat(["name:firefox-wns"], local.sp_tags)
+  client_id = azuread_application.firefox_wns.client_id
+  owners    = local.firefox_wns_owners
+  tags      = concat(["name:firefox-wns"], local.sp_tags)
 }
 
 output "firefox_wns_client_id" {
@@ -42,9 +33,4 @@ output "firefox_wns_client_id" {
 output "firefox_wns_service_principal_object_id" {
   description = "Service principal object ID used as the Windows App SDK WNS remote identifier."
   value       = azuread_service_principal.firefox_wns.object_id
-}
-
-output "firefox_wns_tenant_id" {
-  description = "Mozilla Entra tenant ID used for WNS access-token requests."
-  value       = data.azuread_client_config.current.tenant_id
 }

--- a/terraform/azure_ad/sp_firefox_wns.tf
+++ b/terraform/azure_ad/sp_firefox_wns.tf
@@ -1,0 +1,50 @@
+# Mozilla-owned Entra identity for Firefox Windows App SDK push notification
+# work. This replaces the personal identity used by the Bug 1803416 prototype.
+#
+# WNS requires a multi-tenant application registration and a service principal.
+# The service principal object ID is the remote identifier that Firefox uses to
+# request a WNS channel. The application client ID and Mozilla tenant ID are used
+# by the sender to request an access token for https://wns.windows.com/.default.
+#
+# A client credential is not created here. Add one only after the WNS sender and
+# its approved secret store are defined. Never commit or output the credential.
+
+data "azuread_user" "aborondo" {
+  user_principal_name = "aborondo@mozilla.com"
+}
+
+locals {
+  firefox_wns_owners = setunion(
+    toset(data.azuread_group.relops.members),
+    toset([data.azuread_user.aborondo.object_id]),
+  )
+}
+
+resource "azuread_application" "firefox_wns" {
+  display_name     = "Firefox WNS"
+  description      = "Mozilla-owned identity for Firefox Windows App SDK push notification work (RELOPS-2495, Bug 1803416)."
+  sign_in_audience = "AzureADMultipleOrgs"
+  owners           = local.firefox_wns_owners
+}
+
+resource "azuread_service_principal" "firefox_wns" {
+  client_id                    = azuread_application.firefox_wns.client_id
+  app_role_assignment_required = false
+  owners                       = local.firefox_wns_owners
+  tags                         = concat(["name:firefox-wns"], local.sp_tags)
+}
+
+output "firefox_wns_client_id" {
+  description = "Application client ID used for WNS activation and access-token requests."
+  value       = azuread_application.firefox_wns.client_id
+}
+
+output "firefox_wns_service_principal_object_id" {
+  description = "Service principal object ID used as the Windows App SDK WNS remote identifier."
+  value       = azuread_service_principal.firefox_wns.object_id
+}
+
+output "firefox_wns_tenant_id" {
+  description = "Mozilla Entra tenant ID used for WNS access-token requests."
+  value       = data.azuread_client_config.current.tenant_id
+}


### PR DESCRIPTION
## Summary

- Create a Mozilla-owned, multi-tenant Entra application for Firefox WNS work.
- Create its local service principal.
- Make the existing RelOps group members the owners.
- Export the application client ID and service principal object ID that the Windows App SDK requires.

## Context

[FIDE-3247](https://mozilla-hub.atlassian.net/browse/FIDE-3247) proposes an experiment for web push delivery while Firefox is closed. Its first experiment can use a scheduled Firefox background task. WNS remains the preferred low-latency architecture for a later production implementation.

[Bug 1803416](https://bugzilla.mozilla.org/show_bug.cgi?id=1803416) used a personal Azure identity for the original `pushproxy.exe` prototype. This change provides the Mozilla-owned identity that the investigation needs. It does not approve or deploy the WNS product architecture.

Microsoft requires Windows App SDK push notification applications to use a multi-tenant Entra registration. The application client ID, Mozilla tenant ID, and local service principal object ID are required by the client and sender. The tenant ID already exists in the provider configuration, so this change does not add a duplicate output.

## Security

The application client ID and service principal object ID are identifiers, not credentials.

This change does not create a client secret or another credential. A later change must choose a production credential only after the WNS sender and its credential store are defined. The credential must not be committed or exposed as a Terraform output.

This change does not grant Azure subscription RBAC. WNS uses the Entra directory identity and does not require access to Mozilla Azure resources.

## Validation

- `terraform -chdir=terraform/azure_ad validate`
- `uvx --from pre-commit pre-commit run --files terraform/azure_ad/sp_firefox_wns.tf`
- `git diff --check`
- Autoreview after the ownership change: clean, with no accepted or actionable findings

## Before merge or apply

- Merge or reconcile [PR #313](https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/313). Its Azure AD resources are already in Terraform state but are not in `master`; a plan from `master` currently proposes deleting them.
- Run a new plan and confirm that it only creates the Firefox WNS application and service principal.

References: [RELOPS-2495](https://mozilla-hub.atlassian.net/browse/RELOPS-2495), [Microsoft Windows App SDK WNS quickstart](https://learn.microsoft.com/windows/apps/develop/notifications/push-notifications/push-quickstart)
