### PR TITLE
RELOPS-2487: rebrand WIM store nuc-wim -> hardware-imaging + resources/captured/legacy-images layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# Ignore tfplan output of command: terraform plan -out=tfplan (can embed sensitive values)
+*tfplan*
 
 # Ignore CLI configuration files
 .terraformrc

--- a/terraform/azure_ad/sp_nuc_wim_downloader.tf
+++ b/terraform/azure_ad/sp_nuc_wim_downloader.tf
@@ -6,7 +6,7 @@
 # The MDC1 server authenticates with the SP client_id + secret (stored in
 # kv-central-us-key) using azcopy/az, e.g.:
 #   az login --service-principal -u <client_id> -p <secret> --tenant <tenant>
-#   azcopy copy "https://nucwimfxci.blob.core.windows.net/captured/<wim>" . --auth-mode login
+#   azcopy copy "https://hardwareimaging.blob.core.windows.net/captured/<wim>" . --auth-mode login
 #
 # If the MDC1 server cannot do Entra auth, skip this SP and instead issue a
 # read-only, time-boxed SAS on the 'captured' container and store it in Key Vault.

--- a/terraform/azure_ad/sp_nuc_wim_downloader.tf
+++ b/terraform/azure_ad/sp_nuc_wim_downloader.tf
@@ -1,0 +1,40 @@
+# Service principal used by the on-site MDC1 server to DOWNLOAD baked NUC WIMs
+# from the private (firewalled) storage account (azure_fxci/nuc-wim-storage.tf).
+#
+# Entra auth path: the SP is granted "Storage Blob Data Reader" on the 'captured'
+# container in azure_fxci (via var.nuc_wim_downloader_object_id = this object_id).
+# The MDC1 server authenticates with the SP client_id + secret (stored in
+# kv-central-us-key) using azcopy/az, e.g.:
+#   az login --service-principal -u <client_id> -p <secret> --tenant <tenant>
+#   azcopy copy "https://nucwimfxci.blob.core.windows.net/captured/<wim>" . --auth-mode login
+#
+# If the MDC1 server cannot do Entra auth, skip this SP and instead issue a
+# read-only, time-boxed SAS on the 'captured' container and store it in Key Vault.
+
+resource "azuread_application" "nuc_wim_downloader" {
+  display_name = "sp-relops-nuc-wim-downloader"
+  owners       = [data.azuread_user.mcornmesser.object_id]
+}
+
+resource "azuread_service_principal" "nuc_wim_downloader" {
+  client_id                    = azuread_application.nuc_wim_downloader.client_id
+  app_role_assignment_required = false
+  tags                         = local.sp_tags
+}
+
+# Client secret for the on-site server. Store the value in kv-central-us-key;
+# do not commit it. (Rotate periodically.)
+resource "azuread_application_password" "nuc_wim_downloader" {
+  application_id = azuread_application.nuc_wim_downloader.id
+  display_name   = "mdc1-server"
+  end_date       = "2027-07-21T00:00:00Z"
+}
+
+output "nuc_wim_downloader_object_id" {
+  description = "Feed into azure_fxci var.nuc_wim_downloader_object_id to grant Blob Data Reader."
+  value       = azuread_service_principal.nuc_wim_downloader.object_id
+}
+
+output "nuc_wim_downloader_client_id" {
+  value = azuread_application.nuc_wim_downloader.client_id
+}

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -161,6 +161,45 @@ resource "azurerm_role_assignment" "relops_wim_file_tf" {
   principal_id         = var.relops_group_object_id
 }
 
+# --- Ephemeral build VM identity + workflow SP rights --------------------------
+# The GHA workflow (worker_images_fxci SP) spins an ephemeral nested-virt VM up/down
+# per build. Rather than granting each fresh VM's identity a blob role at runtime
+# (which would need the SP to have role-assignment rights), a user-assigned managed
+# identity is created once and pre-granted blob access; the workflow just attaches it.
+resource "azurerm_user_assigned_identity" "wim_builder" {
+  name                = "id-${local.locationshort}-wim-builder"
+  resource_group_name = azurerm_resource_group.nuc-wim.name
+  location            = azurerm_resource_group.nuc-wim.location
+  tags                = local.common_tags
+}
+
+# The attached UAMI is what actually reads base / writes captured during the bake.
+resource "azurerm_role_assignment" "wim_builder_blob" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.wim_builder.principal_id
+}
+
+# Workflow SP modest rights: create/delete the ephemeral VM + run-command (Contributor
+# scoped to this dedicated RG only — notably NOT role-assignment rights) ...
+resource "azurerm_role_assignment" "wim_workflow_vm" {
+  scope                = azurerm_resource_group.nuc-wim.id
+  role_definition_name = "Contributor"
+  principal_id         = local.worker_images_object_id
+}
+
+# ... and permission to attach the pre-provisioned UAMI to the VM it creates.
+resource "azurerm_role_assignment" "wim_workflow_mi_operator" {
+  scope                = azurerm_user_assigned_identity.wim_builder.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = local.worker_images_object_id
+}
+
+output "nuc_wim_builder_identity_id" {
+  description = "Resource ID of the user-assigned identity to attach to build VMs."
+  value       = azurerm_user_assigned_identity.wim_builder.id
+}
+
 output "nuc_wim_storage_account" {
   value = azurerm_storage_account.nuc-wim.name
 }

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -14,9 +14,11 @@
 #   - MDC1 downloader SP                      -> Blob Data Reader (captured only)
 #   - Relops group (operators)               -> Blob Data Owner + Contributor
 #
-# Containers:
-#   base     - bring-your-own starting install.wim (uploaded once)
-#   captured - baked golden install.wim output by the wim-packer pipeline
+# Containers (folders are blob prefixes, materialized as TF-managed .keep markers):
+#   resources     - SOURCES: WIMs/ (BYO base WIMs), ISOs/ (source Win11 ISOs),
+#                   drivers/ (offline driver packs), tools/ (adksetup + cached oscdimg)
+#   captured      - OUTPUTS: WIMs/ (golden WIMs), ISOs/ (nocheck ISOs)
+#   legacy-images - old, previously-built images (archive; empty at creation)
 #
 # Region Central US to co-locate with Packer / the image galleries.
 # =============================================================================
@@ -72,7 +74,7 @@ resource "azurerm_subnet" "nuc-wim-packer" {
 
 resource "azurerm_storage_account" "nuc-wim" {
   provider                 = azurerm.nuc_wim_aad # keys disabled -> read service props via AAD
-  name                     = "nucwimfxci"
+  name                     = "hardwareimaging"
   resource_group_name      = azurerm_resource_group.nuc-wim.name
   location                 = azurerm_resource_group.nuc-wim.location
   account_tier             = "Standard"
@@ -95,21 +97,53 @@ resource "azurerm_storage_account" "nuc-wim" {
     bypass         = ["AzureServices"]
   }
 
-  tags = merge(local.common_tags, tomap({ "Name" = "nucwimfxci" }))
+  tags = merge(local.common_tags, tomap({ "Name" = "hardwareimaging" }))
 }
 
-resource "azurerm_storage_container" "base" {
+resource "azurerm_storage_container" "resources" {
   provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
-  name                  = "base"
+  name                  = "resources"         # SOURCES (was 'base'): WIMs/ ISOs/ drivers/ tools/
   storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "captured" {
   provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
-  name                  = "captured"
+  name                  = "captured"          # OUTPUTS: WIMs/ (golden WIMs) + ISOs/ (nocheck ISOs)
   storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
+}
+
+# Archive for old images built before / outside this pipeline. Empty at creation.
+resource "azurerm_storage_container" "legacy_images" {
+  provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
+  name                  = "legacy-images"
+  storage_account_id    = azurerm_storage_account.nuc-wim.id
+  container_access_type = "private"
+}
+
+# Folder markers: blob storage has no real folders, so a zero-ish .keep blob per prefix
+# makes the intended structure exist and be TF-managed (create-iso/New-WinHwWim write real
+# blobs under these prefixes). Managed via the AAD provider (account keys are disabled).
+locals {
+  wim_blob_folders = {
+    "resources-wims"    = { container = azurerm_storage_container.resources.name, path = "WIMs/.keep" }
+    "resources-isos"    = { container = azurerm_storage_container.resources.name, path = "ISOs/.keep" }
+    "resources-drivers" = { container = azurerm_storage_container.resources.name, path = "drivers/.keep" }
+    "resources-tools"   = { container = azurerm_storage_container.resources.name, path = "tools/.keep" }
+    "captured-wims"     = { container = azurerm_storage_container.captured.name, path = "WIMs/.keep" }
+    "captured-isos"     = { container = azurerm_storage_container.captured.name, path = "ISOs/.keep" }
+  }
+}
+
+resource "azurerm_storage_blob" "wim_folder_markers" {
+  provider               = azurerm.nuc_wim_aad
+  for_each               = local.wim_blob_folders
+  name                   = each.value.path
+  storage_account_name   = azurerm_storage_account.nuc-wim.name
+  storage_container_name = each.value.container
+  type                   = "Block"
+  source_content         = "Terraform-managed folder marker. Safe to ignore.\n"
 }
 
 # --- Data-plane RBAC (Entra auth; preferred over keys/SAS) ---------------------

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -1,12 +1,18 @@
 # =============================================================================
-# Private (locked-down) Blob storage for NUC Windows install.wim files.
+# Blob storage for NUC Windows install.wim files. ENTRA-ONLY access model.
 #
-# Tier 1 privacy: the account keeps a public endpoint but network_rules default
-# to Deny, so ONLY the allow-listed networks can reach it, and all access still
-# requires auth (Entra RBAC or SAS). No anonymous/public blob access.
-#   - Packer build VM  -> reaches it via the Microsoft.Storage service endpoint
-#                          on the dedicated Packer subnet (below).
-#   - On-site MDC1 srv  -> reaches it from its allow-listed egress IP(s).
+# The account has a public endpoint open to all networks (NO IP firewall), but:
+#   - no anonymous/public blob access, and
+#   - shared account keys are DISABLED — every caller must present an Entra
+#     identity holding a Storage Blob Data RBAC role (grants below).
+# This replaced the earlier IP-allow-list ("Tier 1") posture: split-tunnel VPN
+# made per-workstation IP allow-listing unworkable, and Entra RBAC gates access
+# regardless of source network.
+#
+# Callers (all via Entra / azcopy --auth-mode login):
+#   - Packer build (worker_images SP)        -> Blob Data Contributor
+#   - MDC1 downloader SP                      -> Blob Data Reader (captured only)
+#   - Relops group (operators)               -> Blob Data Owner + Contributor
 #
 # Containers:
 #   base     - bring-your-own starting install.wim (uploaded once)
@@ -15,10 +21,16 @@
 # Region Central US to co-locate with Packer / the image galleries.
 # =============================================================================
 
-variable "mdc1_egress_cidrs" {
-  type        = list(string)
-  description = "Public egress IP/CIDR(s) of the on-site MDC1 server(s) that download the captured WIM. Confirmed with netops 2026-07-23: 63.245.208.129 is the MDC1 egress used by the downloader host. NOTE: Azure storage firewall rejects /31 and /32 — specify a single host as a bare IP (no mask), or use a CIDR with prefix 0-30."
-  default     = ["63.245.208.129"]
+# Aliased provider that manages the Blob data plane via Entra (AAD) rather than
+# the account key — required because shared_access_key_enabled = false below.
+# Scoped to this file's container resources so the rest of azure_fxci (which
+# still manages other storage via keys) is unaffected.
+provider "azurerm" {
+  alias               = "nuc_wim_aad"
+  storage_use_azuread = true
+  features {}
+  subscription_id = "108d46d5-fe9b-4850-9a7d-8c914aa6c1f0"
+  tenant_id       = "c0dc8bb0-b616-427e-8217-9513964a145b"
 }
 
 variable "relops_group_object_id" {
@@ -59,6 +71,7 @@ resource "azurerm_subnet" "nuc-wim-packer" {
 }
 
 resource "azurerm_storage_account" "nuc-wim" {
+  provider                 = azurerm.nuc_wim_aad # keys disabled -> read service props via AAD
   name                     = "nucwimfxci"
   resource_group_name      = azurerm_resource_group.nuc-wim.name
   location                 = azurerm_resource_group.nuc-wim.location
@@ -66,31 +79,34 @@ resource "azurerm_storage_account" "nuc-wim" {
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
 
-  # Tier-1 privacy posture: public endpoint stays, but no anonymous access and
-  # deny-by-default firewall. Auth is always required.
+  # Entra-only posture: public endpoint open to all networks, but no anonymous
+  # access and NO shared account keys — access is gated purely by Entra RBAC.
   https_traffic_only_enabled      = true
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
   public_network_access_enabled   = true
-  shared_access_key_enabled       = true # keep true so a read-only SAS is possible for MDC1
+  shared_access_key_enabled       = false # Entra-only: no account key / SAS
 
+  # No IP firewall — access is controlled by the Storage Blob Data RBAC grants
+  # below, which work from any network. (Removed the IP allow-list: split-tunnel
+  # VPN made per-workstation IPs unworkable.)
   network_rules {
-    default_action             = "Deny"
-    bypass                     = ["AzureServices"]
-    ip_rules                   = var.mdc1_egress_cidrs
-    virtual_network_subnet_ids = [azurerm_subnet.nuc-wim-packer.id]
+    default_action = "Allow"
+    bypass         = ["AzureServices"]
   }
 
   tags = merge(local.common_tags, tomap({ "Name" = "nucwimfxci" }))
 }
 
 resource "azurerm_storage_container" "base" {
+  provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
   name                  = "base"
   storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "captured" {
+  provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
   name                  = "captured"
   storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
@@ -115,9 +131,8 @@ resource "azurerm_role_assignment" "mdc1_wim_ro" {
 }
 
 # Relops group: full data-plane access so operators can manage the store (upload
-# the base WIM, inspect captured output) with their own Entra identity.
-# Owner supersets Contributor; both granted per request. NOTE: the storage
-# firewall still applies — members must reach it from an allow-listed network.
+# the base WIM, inspect captured output) with their own Entra identity, from any
+# network. Owner supersets Contributor; both granted per request.
 resource "azurerm_role_assignment" "relops_wim_data_owner" {
   scope                = azurerm_storage_account.nuc-wim.id
   role_definition_name = "Storage Blob Data Owner"
@@ -127,6 +142,22 @@ resource "azurerm_role_assignment" "relops_wim_data_owner" {
 resource "azurerm_role_assignment" "relops_wim_data_contributor" {
   scope                = azurerm_storage_account.nuc-wim.id
   role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.relops_group_object_id
+}
+
+# The account only uses blob, but with shared keys disabled the azurerm provider
+# reads queue + file *service properties* via AAD when refreshing the account
+# resource. These grants let whoever runs Terraform (operators in Relops) perform
+# those reads; they are not needed for the WIM workflow itself.
+resource "azurerm_role_assignment" "relops_wim_queue_tf" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage Queue Data Contributor"
+  principal_id         = var.relops_group_object_id
+}
+
+resource "azurerm_role_assignment" "relops_wim_file_tf" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = var.relops_group_object_id
 }
 

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -44,39 +44,39 @@ variable "relops_group_object_id" {
 variable "nuc_wim_downloader_object_id" {
   type        = string
   description = "Entra object ID of the SP/managed identity the MDC1 server uses to download (from azure_ad/sp_nuc_wim_downloader.tf output, applied first). Empty = skip the RBAC grant (use SAS instead)."
-  # sp-relops-nuc-wim-downloader (azure_ad/sp_nuc_wim_downloader.tf), applied 2026-07-23.
+  # sp-relops-hardware-imaging-downloader (azure_ad/sp_nuc_wim_downloader.tf), applied 2026-07-23.
   default = "ae54832f-8931-46d8-8faa-133637e72798"
 }
 
-resource "azurerm_resource_group" "nuc-wim" {
-  name     = "rg-${local.locationshort}-nuc-wim"
+resource "azurerm_resource_group" "hardware-imaging" {
+  name     = "rg-${local.locationshort}-hardware-imaging"
   location = local.location
-  tags     = merge(local.common_tags, tomap({ "Name" = "rg-${local.locationshort}-nuc-wim" }))
+  tags     = merge(local.common_tags, tomap({ "Name" = "rg-${local.locationshort}-hardware-imaging" }))
 }
 
 # Dedicated VNet + subnet for Packer builds, with the Storage service endpoint so
 # the build VM's traffic is allowed by the storage firewall (no private endpoint).
-resource "azurerm_virtual_network" "nuc-wim" {
-  name                = "vn-${local.locationshort}-nuc-wim"
-  location            = azurerm_resource_group.nuc-wim.location
-  resource_group_name = azurerm_resource_group.nuc-wim.name
+resource "azurerm_virtual_network" "hardware-imaging" {
+  name                = "vn-${local.locationshort}-hardware-imaging"
+  location            = azurerm_resource_group.hardware-imaging.location
+  resource_group_name = azurerm_resource_group.hardware-imaging.name
   address_space       = ["10.20.0.0/24"]
   tags                = local.common_tags
 }
 
-resource "azurerm_subnet" "nuc-wim-packer" {
-  name                 = "sn-${local.locationshort}-nuc-wim-packer"
-  resource_group_name  = azurerm_resource_group.nuc-wim.name
-  virtual_network_name = azurerm_virtual_network.nuc-wim.name
+resource "azurerm_subnet" "hardware-imaging-packer" {
+  name                 = "sn-${local.locationshort}-hardware-imaging-packer"
+  resource_group_name  = azurerm_resource_group.hardware-imaging.name
+  virtual_network_name = azurerm_virtual_network.hardware-imaging.name
   address_prefixes     = ["10.20.0.0/26"]
   service_endpoints    = ["Microsoft.Storage"]
 }
 
-resource "azurerm_storage_account" "nuc-wim" {
+resource "azurerm_storage_account" "hardware-imaging" {
   provider                 = azurerm.nuc_wim_aad # keys disabled -> read service props via AAD
   name                     = "hardwareimaging"
-  resource_group_name      = azurerm_resource_group.nuc-wim.name
-  location                 = azurerm_resource_group.nuc-wim.location
+  resource_group_name      = azurerm_resource_group.hardware-imaging.name
+  location                 = azurerm_resource_group.hardware-imaging.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
@@ -103,14 +103,14 @@ resource "azurerm_storage_account" "nuc-wim" {
 resource "azurerm_storage_container" "resources" {
   provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
   name                  = "resources"         # SOURCES (was 'base'): WIMs/ ISOs/ drivers/ tools/
-  storage_account_id    = azurerm_storage_account.nuc-wim.id
+  storage_account_id    = azurerm_storage_account.hardware-imaging.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "captured" {
   provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
   name                  = "captured"          # OUTPUTS: WIMs/ (golden WIMs) + ISOs/ (nocheck ISOs)
-  storage_account_id    = azurerm_storage_account.nuc-wim.id
+  storage_account_id    = azurerm_storage_account.hardware-imaging.id
   container_access_type = "private"
 }
 
@@ -118,7 +118,7 @@ resource "azurerm_storage_container" "captured" {
 resource "azurerm_storage_container" "legacy_images" {
   provider              = azurerm.nuc_wim_aad # manage via AAD (keys disabled)
   name                  = "legacy-images"
-  storage_account_id    = azurerm_storage_account.nuc-wim.id
+  storage_account_id    = azurerm_storage_account.hardware-imaging.id
   container_access_type = "private"
 }
 
@@ -140,7 +140,7 @@ resource "azurerm_storage_blob" "wim_folder_markers" {
   provider               = azurerm.nuc_wim_aad
   for_each               = local.wim_blob_folders
   name                   = each.value.path
-  storage_account_name   = azurerm_storage_account.nuc-wim.name
+  storage_account_name   = azurerm_storage_account.hardware-imaging.name
   storage_container_name = each.value.container
   type                   = "Block"
   source_content         = "Terraform-managed folder marker. Safe to ignore.\n"
@@ -150,7 +150,7 @@ resource "azurerm_storage_blob" "wim_folder_markers" {
 # Packer (worker_images SP, object id from keyvault.tf locals) reads base + writes
 # captured -> Storage Blob Data Contributor.
 resource "azurerm_role_assignment" "packer_wim_rw" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = local.worker_images_object_id
 }
@@ -168,13 +168,13 @@ resource "azurerm_role_assignment" "mdc1_wim_ro" {
 # the base WIM, inspect captured output) with their own Entra identity, from any
 # network. Owner supersets Contributor; both granted per request.
 resource "azurerm_role_assignment" "relops_wim_data_owner" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage Blob Data Owner"
   principal_id         = var.relops_group_object_id
 }
 
 resource "azurerm_role_assignment" "relops_wim_data_contributor" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = var.relops_group_object_id
 }
@@ -184,13 +184,13 @@ resource "azurerm_role_assignment" "relops_wim_data_contributor" {
 # resource. These grants let whoever runs Terraform (operators in Relops) perform
 # those reads; they are not needed for the WIM workflow itself.
 resource "azurerm_role_assignment" "relops_wim_queue_tf" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage Queue Data Contributor"
   principal_id         = var.relops_group_object_id
 }
 
 resource "azurerm_role_assignment" "relops_wim_file_tf" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = var.relops_group_object_id
 }
@@ -200,43 +200,43 @@ resource "azurerm_role_assignment" "relops_wim_file_tf" {
 # per build. Rather than granting each fresh VM's identity a blob role at runtime
 # (which would need the SP to have role-assignment rights), a user-assigned managed
 # identity is created once and pre-granted blob access; the workflow just attaches it.
-resource "azurerm_user_assigned_identity" "wim_builder" {
-  name                = "id-${local.locationshort}-wim-builder"
-  resource_group_name = azurerm_resource_group.nuc-wim.name
-  location            = azurerm_resource_group.nuc-wim.location
+resource "azurerm_user_assigned_identity" "hardware_imaging_builder" {
+  name                = "id-${local.locationshort}-hardware-imaging-builder"
+  resource_group_name = azurerm_resource_group.hardware-imaging.name
+  location            = azurerm_resource_group.hardware-imaging.location
   tags                = local.common_tags
 }
 
 # The attached UAMI is what actually reads base / writes captured during the bake.
 resource "azurerm_role_assignment" "wim_builder_blob" {
-  scope                = azurerm_storage_account.nuc-wim.id
+  scope                = azurerm_storage_account.hardware-imaging.id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = azurerm_user_assigned_identity.wim_builder.principal_id
+  principal_id         = azurerm_user_assigned_identity.hardware_imaging_builder.principal_id
 }
 
 # Workflow SP modest rights: create/delete the ephemeral VM + run-command (Contributor
 # scoped to this dedicated RG only — notably NOT role-assignment rights) ...
 resource "azurerm_role_assignment" "wim_workflow_vm" {
-  scope                = azurerm_resource_group.nuc-wim.id
+  scope                = azurerm_resource_group.hardware-imaging.id
   role_definition_name = "Contributor"
   principal_id         = local.worker_images_object_id
 }
 
 # ... and permission to attach the pre-provisioned UAMI to the VM it creates.
 resource "azurerm_role_assignment" "wim_workflow_mi_operator" {
-  scope                = azurerm_user_assigned_identity.wim_builder.id
+  scope                = azurerm_user_assigned_identity.hardware_imaging_builder.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = local.worker_images_object_id
 }
 
 output "nuc_wim_builder_identity_id" {
   description = "Resource ID of the user-assigned identity to attach to build VMs."
-  value       = azurerm_user_assigned_identity.wim_builder.id
+  value       = azurerm_user_assigned_identity.hardware_imaging_builder.id
 }
 
 output "nuc_wim_storage_account" {
-  value = azurerm_storage_account.nuc-wim.name
+  value = azurerm_storage_account.hardware-imaging.name
 }
 output "nuc_wim_packer_subnet_id" {
-  value = azurerm_subnet.nuc-wim-packer.id
+  value = azurerm_subnet.hardware-imaging-packer.id
 }

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -17,14 +17,15 @@
 
 variable "mdc1_egress_cidrs" {
   type        = list(string)
-  description = "Public egress IP/CIDR(s) of the on-site MDC1 server(s) that download the captured WIM. Confirm with netops; 63.245.208.251 is the MDC1 gateway IP already used by the AWS S2S VPN (vpns/usw2.tf)."
-  default     = ["63.245.208.251/32"]
+  description = "Public egress IP/CIDR(s) of the on-site MDC1 server(s) that download the captured WIM. Confirmed with netops 2026-07-23: 63.245.208.129 is the MDC1 egress used by the downloader host. NOTE: Azure storage firewall rejects /31 and /32 — specify a single host as a bare IP (no mask), or use a CIDR with prefix 0-30."
+  default     = ["63.245.208.129"]
 }
 
 variable "nuc_wim_downloader_object_id" {
   type        = string
   description = "Entra object ID of the SP/managed identity the MDC1 server uses to download (from azure_ad/sp_nuc_wim_downloader.tf output, applied first). Empty = skip the RBAC grant (use SAS instead)."
-  default     = ""
+  # sp-relops-nuc-wim-downloader (azure_ad/sp_nuc_wim_downloader.tf), applied 2026-07-23.
+  default = "ae54832f-8931-46d8-8faa-133637e72798"
 }
 
 resource "azurerm_resource_group" "nuc-wim" {
@@ -79,13 +80,13 @@ resource "azurerm_storage_account" "nuc-wim" {
 
 resource "azurerm_storage_container" "base" {
   name                  = "base"
-  storage_account_name  = azurerm_storage_account.nuc-wim.name
+  storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "captured" {
   name                  = "captured"
-  storage_account_name  = azurerm_storage_account.nuc-wim.name
+  storage_account_id    = azurerm_storage_account.nuc-wim.id
   container_access_type = "private"
 }
 
@@ -102,7 +103,7 @@ resource "azurerm_role_assignment" "packer_wim_rw" {
 # Scoped to the 'captured' container only. Skipped when object id is empty (SAS path).
 resource "azurerm_role_assignment" "mdc1_wim_ro" {
   count                = var.nuc_wim_downloader_object_id == "" ? 0 : 1
-  scope                = azurerm_storage_container.captured.resource_manager_id
+  scope                = azurerm_storage_container.captured.id
   role_definition_name = "Storage Blob Data Reader"
   principal_id         = var.nuc_wim_downloader_object_id
 }

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -21,16 +21,10 @@ variable "mdc1_egress_cidrs" {
   default     = ["63.245.208.129"]
 }
 
-variable "admin_egress_cidrs" {
-  type        = list(string)
-  description = "Operator/admin egress IPs allowed to manage the WIM store (e.g. upload the base WIM) from outside MDC1. Defaults to the Mozilla corporate VPN netblocks (see terraform/base/outputs.tf mozilla_vpn_netblocks and https://mana.mozilla.org/wiki/display/IT/Mozilla+VPN#MozillaVPN-RelevantIPs). NOTE: listed as /32 upstream, but Azure storage firewall rejects /32 — use bare IPs here."
-  default = [
-    "63.245.208.132",
-    "63.245.208.133",
-    "63.245.210.132",
-    "63.245.210.133",
-    "185.155.182.210",
-  ]
+variable "relops_group_object_id" {
+  type        = string
+  description = "Entra object ID of the Relops group. Members get data-plane Blob roles on the WIM store so operators can manage it (e.g. upload the base WIM) with their own Entra identity."
+  default     = "cb79b99f-fdaa-4e0d-a2c8-c5841890fa74" # Relops
 }
 
 variable "nuc_wim_downloader_object_id" {
@@ -83,7 +77,7 @@ resource "azurerm_storage_account" "nuc-wim" {
   network_rules {
     default_action             = "Deny"
     bypass                     = ["AzureServices"]
-    ip_rules                   = concat(var.mdc1_egress_cidrs, var.admin_egress_cidrs)
+    ip_rules                   = var.mdc1_egress_cidrs
     virtual_network_subnet_ids = [azurerm_subnet.nuc-wim-packer.id]
   }
 
@@ -118,6 +112,22 @@ resource "azurerm_role_assignment" "mdc1_wim_ro" {
   scope                = azurerm_storage_container.captured.id
   role_definition_name = "Storage Blob Data Reader"
   principal_id         = var.nuc_wim_downloader_object_id
+}
+
+# Relops group: full data-plane access so operators can manage the store (upload
+# the base WIM, inspect captured output) with their own Entra identity.
+# Owner supersets Contributor; both granted per request. NOTE: the storage
+# firewall still applies — members must reach it from an allow-listed network.
+resource "azurerm_role_assignment" "relops_wim_data_owner" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = var.relops_group_object_id
+}
+
+resource "azurerm_role_assignment" "relops_wim_data_contributor" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.relops_group_object_id
 }
 
 output "nuc_wim_storage_account" {

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -21,6 +21,18 @@ variable "mdc1_egress_cidrs" {
   default     = ["63.245.208.129"]
 }
 
+variable "admin_egress_cidrs" {
+  type        = list(string)
+  description = "Operator/admin egress IPs allowed to manage the WIM store (e.g. upload the base WIM) from outside MDC1. Defaults to the Mozilla corporate VPN netblocks (see terraform/base/outputs.tf mozilla_vpn_netblocks and https://mana.mozilla.org/wiki/display/IT/Mozilla+VPN#MozillaVPN-RelevantIPs). NOTE: listed as /32 upstream, but Azure storage firewall rejects /32 — use bare IPs here."
+  default = [
+    "63.245.208.132",
+    "63.245.208.133",
+    "63.245.210.132",
+    "63.245.210.133",
+    "185.155.182.210",
+  ]
+}
+
 variable "nuc_wim_downloader_object_id" {
   type        = string
   description = "Entra object ID of the SP/managed identity the MDC1 server uses to download (from azure_ad/sp_nuc_wim_downloader.tf output, applied first). Empty = skip the RBAC grant (use SAS instead)."
@@ -71,7 +83,7 @@ resource "azurerm_storage_account" "nuc-wim" {
   network_rules {
     default_action             = "Deny"
     bypass                     = ["AzureServices"]
-    ip_rules                   = var.mdc1_egress_cidrs
+    ip_rules                   = concat(var.mdc1_egress_cidrs, var.admin_egress_cidrs)
     virtual_network_subnet_ids = [azurerm_subnet.nuc-wim-packer.id]
   }
 

--- a/terraform/azure_fxci/nuc-wim-storage.tf
+++ b/terraform/azure_fxci/nuc-wim-storage.tf
@@ -1,0 +1,115 @@
+# =============================================================================
+# Private (locked-down) Blob storage for NUC Windows install.wim files.
+#
+# Tier 1 privacy: the account keeps a public endpoint but network_rules default
+# to Deny, so ONLY the allow-listed networks can reach it, and all access still
+# requires auth (Entra RBAC or SAS). No anonymous/public blob access.
+#   - Packer build VM  -> reaches it via the Microsoft.Storage service endpoint
+#                          on the dedicated Packer subnet (below).
+#   - On-site MDC1 srv  -> reaches it from its allow-listed egress IP(s).
+#
+# Containers:
+#   base     - bring-your-own starting install.wim (uploaded once)
+#   captured - baked golden install.wim output by the wim-packer pipeline
+#
+# Region Central US to co-locate with Packer / the image galleries.
+# =============================================================================
+
+variable "mdc1_egress_cidrs" {
+  type        = list(string)
+  description = "Public egress IP/CIDR(s) of the on-site MDC1 server(s) that download the captured WIM. Confirm with netops; 63.245.208.251 is the MDC1 gateway IP already used by the AWS S2S VPN (vpns/usw2.tf)."
+  default     = ["63.245.208.251/32"]
+}
+
+variable "nuc_wim_downloader_object_id" {
+  type        = string
+  description = "Entra object ID of the SP/managed identity the MDC1 server uses to download (from azure_ad/sp_nuc_wim_downloader.tf output, applied first). Empty = skip the RBAC grant (use SAS instead)."
+  default     = ""
+}
+
+resource "azurerm_resource_group" "nuc-wim" {
+  name     = "rg-${local.locationshort}-nuc-wim"
+  location = local.location
+  tags     = merge(local.common_tags, tomap({ "Name" = "rg-${local.locationshort}-nuc-wim" }))
+}
+
+# Dedicated VNet + subnet for Packer builds, with the Storage service endpoint so
+# the build VM's traffic is allowed by the storage firewall (no private endpoint).
+resource "azurerm_virtual_network" "nuc-wim" {
+  name                = "vn-${local.locationshort}-nuc-wim"
+  location            = azurerm_resource_group.nuc-wim.location
+  resource_group_name = azurerm_resource_group.nuc-wim.name
+  address_space       = ["10.20.0.0/24"]
+  tags                = local.common_tags
+}
+
+resource "azurerm_subnet" "nuc-wim-packer" {
+  name                 = "sn-${local.locationshort}-nuc-wim-packer"
+  resource_group_name  = azurerm_resource_group.nuc-wim.name
+  virtual_network_name = azurerm_virtual_network.nuc-wim.name
+  address_prefixes     = ["10.20.0.0/26"]
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "nuc-wim" {
+  name                     = "nucwimfxci"
+  resource_group_name      = azurerm_resource_group.nuc-wim.name
+  location                 = azurerm_resource_group.nuc-wim.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+
+  # Tier-1 privacy posture: public endpoint stays, but no anonymous access and
+  # deny-by-default firewall. Auth is always required.
+  https_traffic_only_enabled      = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  public_network_access_enabled   = true
+  shared_access_key_enabled       = true # keep true so a read-only SAS is possible for MDC1
+
+  network_rules {
+    default_action             = "Deny"
+    bypass                     = ["AzureServices"]
+    ip_rules                   = var.mdc1_egress_cidrs
+    virtual_network_subnet_ids = [azurerm_subnet.nuc-wim-packer.id]
+  }
+
+  tags = merge(local.common_tags, tomap({ "Name" = "nucwimfxci" }))
+}
+
+resource "azurerm_storage_container" "base" {
+  name                  = "base"
+  storage_account_name  = azurerm_storage_account.nuc-wim.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "captured" {
+  name                  = "captured"
+  storage_account_name  = azurerm_storage_account.nuc-wim.name
+  container_access_type = "private"
+}
+
+# --- Data-plane RBAC (Entra auth; preferred over keys/SAS) ---------------------
+# Packer (worker_images SP, object id from keyvault.tf locals) reads base + writes
+# captured -> Storage Blob Data Contributor.
+resource "azurerm_role_assignment" "packer_wim_rw" {
+  scope                = azurerm_storage_account.nuc-wim.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = local.worker_images_object_id
+}
+
+# MDC1 downloader (if using Entra auth) reads captured -> Storage Blob Data Reader.
+# Scoped to the 'captured' container only. Skipped when object id is empty (SAS path).
+resource "azurerm_role_assignment" "mdc1_wim_ro" {
+  count                = var.nuc_wim_downloader_object_id == "" ? 0 : 1
+  scope                = azurerm_storage_container.captured.resource_manager_id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = var.nuc_wim_downloader_object_id
+}
+
+output "nuc_wim_storage_account" {
+  value = azurerm_storage_account.nuc-wim.name
+}
+output "nuc_wim_packer_subnet_id" {
+  value = azurerm_subnet.nuc-wim-packer.id
+}


### PR DESCRIPTION
Prod-prep for the Windows HW imaging store.

- Storage account `nucwimfxci` -> **`hardwareimaging`**
- RG/VNet/subnet/UAMI rebranded `nuc-wim` -> `hardware-imaging`
- Container `base` -> `resources` (SOURCES: WIMs/ ISOs/ drivers/ tools/); `captured` gains WIMs/ + ISOs/; new **`legacy-images`** container (old previously-built images)
- TF-managed `.keep` folder markers for those prefixes
- Downloader SP `sp-relops-nuc-wim-downloader` intentionally NOT renamed (would rotate its secret)

`terraform validate` clean. Plan (targeted): **23 add / 16 destroy** (full teardown+rebuild — the account name is ForceNew).

⚠️ **Apply is phased to avoid data loss:** create the new stack first, migrate blobs (base/* -> resources/WIMs|ISOs|drivers|tools; captured/* -> captured/WIMs|ISOs), cut worker-images over (mozilla-platform-ops/worker-images#852), then retire the old RG. See WORKLOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)