### PR TITLE
RELOPS-2502: add pjha to Microsoft Store Partner Center groups

### DIFF
--- a/terraform/azure_ad/terraform.tfvars
+++ b/terraform/azure_ad/terraform.tfvars
@@ -138,7 +138,8 @@ seio_group = [
 
 # Amir Habibi, Ben Hearsum, Chris DuPuis, David Rubino, Dianna Smith, Jonathan Moss,
 # Julia Gibbs, Julien Cristau, Mark Cornmesser, Markco Test (test account), Marlene Hirose,
-# nalexander, Noel De La Torre, Pascal Chevrel, rkelimutu, Romain Testard, Ryan VanderMeulen
+# nalexander, Noel De La Torre, Paresh Jha, Pascal Chevrel, rkelimutu, Romain Testard,
+# Ryan VanderMeulen
 ms_store_publishers_group = [
   "ahabibi@mozilla.com",
   "bhearsum@mozilla.com",
@@ -152,6 +153,8 @@ ms_store_publishers_group = [
   "markco_test@mozilla.com",
   "nalexander@mozilla.com",
   "ndelatorre@mozilla.com",
+  # RELOPS-2502 — vouched by Amir Habibi; Partner Center asset updates
+  "pjha@mozilla.com",
   "pchevrel@mozilla.com",
   "rkelimutu@mozilla.com",
   "rtestard@mozilla.com",
@@ -160,8 +163,8 @@ ms_store_publishers_group = [
 
 # Alex Davis, Amir Habibi, Ben Hearsum, David Rubino, Julia Gibbs, Julien Cristau,
 # Lauren Niolet, Mark Cornmesser, Mark Toubman, Markco Test (test account), Marlene Hirose,
-# Nadia Florez, Noel De La Torre, Norberto Andres Furlan, Richard Baffour-Awuah,
-# Romain Testard, Ryan VanderMeulen, Su-Young Hong
+# Nadia Florez, Noel De La Torre, Norberto Andres Furlan, Paresh Jha,
+# Richard Baffour-Awuah, Romain Testard, Ryan VanderMeulen, Su-Young Hong
 ms_store_finance_group = [
   "adavis@mozilla.com",
   "ahabibi@mozilla.com",
@@ -176,6 +179,8 @@ ms_store_finance_group = [
   "nflorez@mozilla.com",
   "ndelatorre@mozilla.com",
   "nfurlan@mozilla.com",
+  # RELOPS-2502 — vouched by Amir Habibi; parity with ahabibi@ per request
+  "pjha@mozilla.com",
   "rbaffourawuah@mozilla.com",
   "rtestard@mozilla.com",
   "rvandermeulen@mozilla.com",


### PR DESCRIPTION
Grants Paresh Jha (`pjha@mozilla.com`) access to the Microsoft Store Partner Center, at parity with `ahabibi@` as requested in [RELOPS-2502](https://mozilla-hub.atlassian.net/browse/RELOPS-2502).

Adds him to `ms_store_publishers_group` and `ms_store_finance_group`. Neither group carries Azure RBAC — access is entirely via the Partner Center portal, per the comments in `groups.tf`.

## Preconditions verified against the tenant

- Vouched by Amir Habibi (ticket comment, 2026-08-06).
- `pjha@mozilla.com` exists in Entra.
- MFA enrolled as of 2026-08-12 00:22 UTC, per the Graph `userRegistrationDetails` report.

## Expected plan

Two new `azuread_group_member` resources, nothing else.

## Note

The MFA method registered is `mobilePhone` (SMS). That matches Amir, whom this request is at parity with, and three other members of the Publishers group — so it isn't an outlier, but it is weaker than the rest of the group. Tracked separately in [RELOPS-2513](https://mozilla-hub.atlassian.net/browse/RELOPS-2513), which proposes a Conditional Access policy requiring an authenticator app for Partner Center. No enforcement change is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)